### PR TITLE
Load guide content from index

### DIFF
--- a/src/components/training/TrainingGuideSection.tsx
+++ b/src/components/training/TrainingGuideSection.tsx
@@ -23,46 +23,14 @@ const TrainingGuideSection: React.FC<TrainingGuideSectionProps> = ({
   guideContent,
   steps: propSteps
 }) => {
-  // デフォルトコンテンツ
-  const defaultSteps = [
-    {
-      title: '要件からユーザーが達成するべき目的を整理',
-      description: '自分が良いと思うではなく、使う人目線の条件を達成するUI作成能力をトレーニングするお題です。',
-      referenceLink: {
-        text: 'ユーザー中心設計の基本',
-        url: '#'
-      }
-    },
-    {
-      title: '情報の優先順位を設計する',
-      description: 'ユーザーが必要とする情報を適切な順序で配置し、効率的な体験を提供するための設計手法を学びます。',
-    },
-    {
-      title: 'UIコンポーネントの選定と配置',
-      description: '目的に応じた適切なUIコンポーネントを選び、ユーザビリティを考慮した配置を行います。',
-    },
-    {
-      title: 'デザインシステムの活用',
-      description: '一貫性のあるデザインを効率的に作成するため、デザインシステムを理解し活用します。',
-    },
-    {
-      title: 'プロトタイプの作成と検証',
-      description: '実際に動作するプロトタイプを作成し、ユーザーテストを通じて設計の妥当性を検証します。',
-    }
-  ];
+  // デフォルト文言
+  const defaultTitle = '進め方ガイド';
+  const defaultDescription = 'デザイン基礎を身につけながらデザインするための\nやり方の流れを説明します。';
 
-  const defaultLessonCard = {
-    title: 'ゼロからはじめる情報設計',
-    emoji: '📚',
-    description: '進め方の基礎はBONOで詳細に学習・実践できます',
-    link: '/training'
-  };
-
-  // 使用するデータを決定（デフォルトのみ使用）
-  const title = '進め方ガイド';
-  const description = 'デザイン基礎を身につけながらデザインするための\nやり方の流れを説明します。';
-  const lessonCard = defaultLessonCard;
-  const steps = defaultSteps;
+  const title = guideContent?.title || defaultTitle;
+  const description = guideContent?.description || defaultDescription;
+  const lessonCard = guideContent?.lessonCard;
+  const steps = propSteps ?? guideContent?.steps ?? [];
   return (
     <section className="w-full py-16 px-4 bg-white">
       <div className="max-w-3xl mx-auto">

--- a/src/pages/TrainingDetail.tsx
+++ b/src/pages/TrainingDetail.tsx
@@ -11,7 +11,7 @@ import { TrainingError } from '@/utils/errors';
 import { TrainingFrontmatter } from '@/types/training';
 import { useState, useEffect } from 'react';
 import { loadTrainingContent } from '@/utils/loadTrainingContent';
-import { extractSkillSection, removeSkillAndGuideSection, extractSkillTitles, extractGuideSection, parseGuideContent } from '@/utils/processSkillSection';
+import { extractSkillSection, removeSkillAndGuideSection, extractSkillTitles, extractGuideSection, parseGuideContent, GuideContent } from '@/utils/processSkillSection';
 import ChallengeMeritSection from '@/components/training/ChallengeMeritSection';
 import CategoryTag from '@/components/training/CategoryTag';
 import TrainingGuideSection from '@/components/training/TrainingGuideSection';
@@ -25,6 +25,7 @@ const TrainingDetail = () => {
   const [markdownContent, setMarkdownContent] = useState<string>('');
   const [frontmatter, setFrontmatter] = useState<TrainingFrontmatter | null>(null);
   const [contentError, setContentError] = useState<string | null>(null);
+  const [guideContent, setGuideContent] = useState<GuideContent | undefined>();
   
   if (!trainingSlug) {
     return <Navigate to="/training" replace />;
@@ -40,11 +41,15 @@ const TrainingDetail = () => {
         const { frontmatter, content } = await loadTrainingContent(trainingSlug);
         setFrontmatter(frontmatter);
         setMarkdownContent(content);
+        const guideSection = extractGuideSection(content);
+        const parsedGuide = parseGuideContent(guideSection);
+        setGuideContent(parsedGuide);
       } catch (error) {
         console.error('コンテンツ読み込みエラー:', error);
         setContentError(error instanceof Error ? error.message : 'コンテンツの読み込みに失敗しました');
         setFrontmatter(null);
         setMarkdownContent('');
+        setGuideContent(undefined);
       }
     };
 
@@ -471,7 +476,7 @@ task_count: 2
         )}
 
         {/* 進め方ガイドセクション */}
-        <TrainingGuideSection />
+        <TrainingGuideSection guideContent={guideContent} />
 
         {/* マークダウンコンテンツ（スキルセクションと進め方ガイドを除外） */}
         {markdownContent && (


### PR DESCRIPTION
## Summary
- parse guide info from each training `index.md`
- pass parsed guide content to `TrainingGuideSection`
- display lesson and steps only when provided

## Testing
- `npm run lint` *(fails: many eslint violations)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885e08c5c18832f94b4c54dbe015b41