### PR TITLE
feat(training): Sanity CMSへの完全移行

### DIFF
--- a/sanity-studio/schemaTypes/index.ts
+++ b/sanity-studio/schemaTypes/index.ts
@@ -12,9 +12,11 @@ import feedbackCategory from "./feedbackCategory";
 import knowledge from "./knowledge";
 import knowledgeCategory from "./knowledgeCategory";
 import userOutput from "./userOutput";
+import training from "./training";
+import trainingTask from "./trainingTask";
 import customContainer from "./objects/customContainer";
 import tableBlock from "./objects/tableBlock";
 import linkCard from "./objects/linkCard";
 import tableOfContents from "./objects/tableOfContents";
 
-export const schemaTypes = [category, lesson, quest, article, roadmap, blogPost, event, question, questionCategory, feedback, feedbackCategory, knowledge, knowledgeCategory, userOutput, customContainer, tableBlock, linkCard, tableOfContents];
+export const schemaTypes = [category, lesson, quest, article, roadmap, blogPost, event, question, questionCategory, feedback, feedbackCategory, knowledge, knowledgeCategory, userOutput, training, trainingTask, customContainer, tableBlock, linkCard, tableOfContents];

--- a/sanity-studio/schemaTypes/training.ts
+++ b/sanity-studio/schemaTypes/training.ts
@@ -1,0 +1,208 @@
+import { defineType, defineField } from "sanity";
+
+export default defineType({
+  name: "training",
+  title: "トレーニング",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "タイトル",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "slug",
+      title: "スラッグ",
+      type: "slug",
+      options: {
+        source: "title",
+        maxLength: 96,
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "説明",
+      type: "text",
+      rows: 5,
+    }),
+    defineField({
+      name: "trainingType",
+      title: "トレーニングタイプ",
+      type: "string",
+      options: {
+        list: [
+          { title: "チャレンジ", value: "challenge" },
+          { title: "スキル", value: "skill" },
+          { title: "ポートフォリオ", value: "portfolio" },
+        ],
+        layout: "radio",
+      },
+      initialValue: "challenge",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "difficulty",
+      title: "難易度",
+      type: "string",
+      options: {
+        list: [
+          { title: "かんたん", value: "easy" },
+          { title: "ふつう", value: "normal" },
+          { title: "むずかしい", value: "hard" },
+        ],
+      },
+      initialValue: "normal",
+    }),
+    defineField({
+      name: "category",
+      title: "カテゴリ",
+      type: "reference",
+      to: [{ type: "category" }],
+    }),
+    defineField({
+      name: "tags",
+      title: "タグ",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { layout: "tags" },
+    }),
+    defineField({
+      name: "isPremium",
+      title: "有料トレーニング",
+      type: "boolean",
+      initialValue: false,
+    }),
+    defineField({
+      name: "orderIndex",
+      title: "表示順序",
+      type: "number",
+      description: "小さい数字ほど先に表示",
+      initialValue: 0,
+    }),
+    defineField({
+      name: "iconImage",
+      title: "アイコン画像",
+      type: "image",
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: "iconImageUrl",
+      title: "アイコン画像URL",
+      type: "url",
+    }),
+    defineField({
+      name: "thumbnail",
+      title: "サムネイル画像",
+      type: "image",
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: "thumbnailUrl",
+      title: "サムネイル画像URL",
+      type: "url",
+    }),
+    defineField({
+      name: "backgroundSvg",
+      title: "背景SVG URL",
+      type: "url",
+      description: "カード背景に使用するSVG画像のURL",
+    }),
+    defineField({
+      name: "fallbackGradient",
+      title: "フォールバックグラデーション",
+      type: "object",
+      fields: [
+        { name: "from", title: "From", type: "string" },
+        { name: "via", title: "Via", type: "string" },
+        { name: "to", title: "To", type: "string" },
+      ],
+      description: "背景画像がない場合のグラデーション色（Hex）",
+    }),
+    defineField({
+      name: "estimatedTotalTime",
+      title: "想定所要時間",
+      type: "string",
+      description: "例: 4-5時間",
+    }),
+    defineField({
+      name: "skills",
+      title: "身につくスキル",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            { name: "title", title: "タイトル", type: "string" },
+            { name: "description", title: "説明", type: "text", rows: 3 },
+            { name: "referenceLink", title: "参考リンク", type: "url" },
+          ],
+          preview: {
+            select: { title: "title" },
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: "guide",
+      title: "進め方ガイド",
+      type: "object",
+      fields: [
+        { name: "title", title: "ガイドタイトル", type: "string" },
+        { name: "description", title: "ガイド説明", type: "text" },
+        {
+          name: "lesson",
+          title: "関連レッスン",
+          type: "object",
+          fields: [
+            { name: "title", title: "タイトル", type: "string" },
+            { name: "image", title: "画像URL", type: "url" },
+            { name: "description", title: "説明", type: "text" },
+            { name: "link", title: "リンク", type: "url" },
+          ],
+        },
+        {
+          name: "steps",
+          title: "ステップ",
+          type: "array",
+          of: [
+            {
+              type: "object",
+              fields: [
+                { name: "title", title: "タイトル", type: "string" },
+                { name: "description", title: "説明", type: "text", rows: 3 },
+              ],
+              preview: {
+                select: { title: "title" },
+              },
+            },
+          ],
+        },
+      ],
+    }),
+    defineField({
+      name: "tasks",
+      title: "タスク",
+      type: "array",
+      of: [{ type: "reference", to: [{ type: "trainingTask" }] }],
+      description: "このトレーニングに含まれるタスク（ドラッグ&ドロップで並べ替え可能）",
+    }),
+  ],
+  preview: {
+    select: {
+      title: "title",
+      media: "thumbnail",
+      trainingType: "trainingType",
+      isPremium: "isPremium",
+    },
+    prepare({ title, media, trainingType, isPremium }) {
+      const typeLabel = { challenge: "チャレンジ", skill: "スキル", portfolio: "ポートフォリオ" }[trainingType] || trainingType;
+      return {
+        title,
+        media,
+        subtitle: `${typeLabel}${isPremium ? " 🔒" : ""}`,
+      };
+    },
+  },
+});

--- a/sanity-studio/schemaTypes/trainingTask.ts
+++ b/sanity-studio/schemaTypes/trainingTask.ts
@@ -1,0 +1,191 @@
+import { defineType, defineField } from "sanity";
+import { MarkdownImportInput } from "../components/MarkdownImportInput";
+
+export default defineType({
+  name: "trainingTask",
+  title: "トレーニングタスク",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "タイトル",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "slug",
+      title: "スラッグ",
+      type: "slug",
+      options: {
+        source: "title",
+        maxLength: 96,
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "説明",
+      type: "text",
+      rows: 3,
+    }),
+    defineField({
+      name: "orderIndex",
+      title: "表示順序",
+      type: "number",
+      description: "タスクの順序番号（1, 2, 3...）",
+      validation: (Rule) => Rule.required().min(1),
+      initialValue: 1,
+    }),
+    defineField({
+      name: "isPremium",
+      title: "有料タスク",
+      type: "boolean",
+      initialValue: false,
+    }),
+    defineField({
+      name: "category",
+      title: "カテゴリ",
+      type: "string",
+      description: "タスクのカテゴリ（例: 情報設計、UIデザイン）",
+    }),
+    defineField({
+      name: "tags",
+      title: "タグ",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { layout: "tags" },
+    }),
+    defineField({
+      name: "videoFull",
+      title: "動画URL（会員用）",
+      type: "url",
+      description: "会員向けフル動画のURL（Vimeo等）",
+    }),
+    defineField({
+      name: "videoPreview",
+      title: "動画URL（プレビュー）",
+      type: "url",
+      description: "無料プレビュー動画のURL",
+    }),
+    defineField({
+      name: "previewSec",
+      title: "プレビュー秒数",
+      type: "number",
+      description: "プレビューとして表示する秒数",
+    }),
+    defineField({
+      name: "training",
+      title: "所属トレーニング",
+      type: "reference",
+      to: [{ type: "training" }],
+      description: "このタスクが所属するトレーニング",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "sections",
+      title: "コンテンツセクション",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            {
+              name: "sectionTitle",
+              title: "セクションタイトル",
+              type: "string",
+            },
+            {
+              name: "sectionType",
+              title: "セクションタイプ",
+              type: "string",
+              options: {
+                list: [
+                  { title: "通常", value: "regular" },
+                  { title: "デザイン解答例", value: "design-solution" },
+                  { title: "有料限定", value: "premium-only" },
+                ],
+              },
+              initialValue: "regular",
+            },
+            {
+              name: "content",
+              title: "コンテンツ",
+              type: "array",
+              of: [
+                {
+                  type: "block",
+                  styles: [
+                    { title: "Normal", value: "normal" },
+                    { title: "H2", value: "h2" },
+                    { title: "H3", value: "h3" },
+                    { title: "H4", value: "h4" },
+                    { title: "Quote", value: "blockquote" },
+                  ],
+                  marks: {
+                    decorators: [
+                      { title: "太字", value: "strong" },
+                      { title: "斜体", value: "em" },
+                      { title: "コード", value: "code" },
+                    ],
+                    annotations: [
+                      {
+                        title: "リンク",
+                        name: "link",
+                        type: "object",
+                        fields: [
+                          { title: "URL", name: "href", type: "url" },
+                        ],
+                      },
+                    ],
+                  },
+                },
+                {
+                  type: "image",
+                  options: { hotspot: true },
+                  fields: [
+                    { name: "alt", type: "string", title: "代替テキスト" },
+                    { name: "caption", type: "string", title: "キャプション" },
+                  ],
+                },
+              ],
+              components: {
+                input: MarkdownImportInput,
+              },
+              description: "リッチテキストで記述。Markdownインポートも可能。",
+            },
+          ],
+          preview: {
+            select: {
+              title: "sectionTitle",
+              sectionType: "sectionType",
+            },
+            prepare({ title, sectionType }) {
+              const typeLabel = {
+                regular: "",
+                "design-solution": "🎨 ",
+                "premium-only": "🔒 ",
+              }[sectionType] || "";
+              return {
+                title: `${typeLabel}${title || "無題のセクション"}`,
+              };
+            },
+          },
+        },
+      ],
+    }),
+  ],
+  preview: {
+    select: {
+      title: "title",
+      orderIndex: "orderIndex",
+      isPremium: "isPremium",
+      trainingTitle: "training.title",
+    },
+    prepare({ title, orderIndex, isPremium, trainingTitle }) {
+      return {
+        title: `${orderIndex || "?"} . ${title}`,
+        subtitle: `📋 ${trainingTitle || "未設定"}${isPremium ? " 🔒" : ""}`,
+      };
+    },
+  },
+});

--- a/sanity-studio/scripts/migrate-training.ts
+++ b/sanity-studio/scripts/migrate-training.ts
@@ -1,0 +1,552 @@
+/**
+ * Training コンテンツ移行スクリプト
+ * /content/training/ のMarkdownファイルをSanityに投入する
+ *
+ * 使い方:
+ *   cd sanity-studio
+ *   npx tsx scripts/migrate-training.ts
+ *
+ * 環境変数:
+ *   SANITY_STUDIO_PROJECT_ID (sanity.config.ts から取得)
+ *   SANITY_STUDIO_DATASET (デフォルト: development)
+ *   SANITY_AUTH_TOKEN (Sanity管理画面で発行)
+ */
+
+import { createClient } from "@sanity/client";
+import * as fs from "fs";
+import * as path from "path";
+
+// --- 設定 ---
+const PROJECT_ID = "cqszh4up";
+const DATASET = process.env.SANITY_STUDIO_DATASET || "development";
+const TOKEN = process.env.SANITY_AUTH_TOKEN;
+
+if (!TOKEN) {
+  console.error("❌ SANITY_AUTH_TOKEN が設定されていません");
+  console.error("   Sanity管理画面 → Settings → API → Tokens で発行してください");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: PROJECT_ID,
+  dataset: DATASET,
+  token: TOKEN,
+  useCdn: false,
+  apiVersion: "2024-01-01",
+});
+
+const CONTENT_DIR = path.resolve(__dirname, "../../content/training");
+
+// --- YAML フロントマターパーサー ---
+function parseFrontmatter(content: string): { frontmatter: Record<string, any>; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, body: content };
+
+  const yamlStr = match[1];
+  const body = match[2];
+  const frontmatter = parseYaml(yamlStr);
+  return { frontmatter, body };
+}
+
+function parseYaml(yaml: string): Record<string, any> {
+  const result: Record<string, any> = {};
+  const lines = yaml.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const keyMatch = line.match(/^(\w[\w_]*)\s*:\s*(.*)/);
+
+    if (!keyMatch) {
+      i++;
+      continue;
+    }
+
+    const key = keyMatch[1];
+    let value = keyMatch[2].trim();
+
+    // 配列 (インライン)
+    if (value.startsWith("[")) {
+      result[key] = value
+        .slice(1, -1)
+        .split(",")
+        .map((v) => v.trim().replace(/^["']|["']$/g, ""));
+      i++;
+      continue;
+    }
+
+    // 配列/オブジェクト (ブロック)
+    if (value === "" || value === "|") {
+      const isMultiline = value === "|";
+      const children = collectIndentedBlock(lines, i + 1);
+
+      if (children.length > 0 && children[0].trimStart().startsWith("- ")) {
+        result[key] = parseYamlArray(children);
+      } else if (isMultiline) {
+        result[key] = children.map((l) => l.replace(/^ {2,}/, "")).join("\n");
+      } else {
+        result[key] = parseYamlObject(children);
+      }
+      i += children.length + 1;
+      continue;
+    }
+
+    // ブール値
+    if (value === "true") { result[key] = true; i++; continue; }
+    if (value === "false") { result[key] = false; i++; continue; }
+
+    // 数値
+    if (/^\d+$/.test(value)) { result[key] = parseInt(value, 10); i++; continue; }
+
+    // 文字列
+    result[key] = value.replace(/^["']|["']$/g, "");
+    i++;
+  }
+
+  return result;
+}
+
+function collectIndentedBlock(lines: string[], start: number): string[] {
+  const block: string[] = [];
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i] === "" || /^\s+/.test(lines[i])) {
+      block.push(lines[i]);
+    } else {
+      break;
+    }
+  }
+  // 末尾の空行を削除
+  while (block.length > 0 && block[block.length - 1].trim() === "") {
+    block.pop();
+  }
+  return block;
+}
+
+function parseYamlArray(lines: string[]): any[] {
+  const items: any[] = [];
+  let currentItem: string[] = [];
+
+  for (const line of lines) {
+    if (line.trimStart().startsWith("- ") && !line.trimStart().startsWith("- -")) {
+      if (currentItem.length > 0) {
+        items.push(parseYamlArrayItem(currentItem));
+      }
+      currentItem = [line];
+    } else {
+      currentItem.push(line);
+    }
+  }
+  if (currentItem.length > 0) {
+    items.push(parseYamlArrayItem(currentItem));
+  }
+
+  return items;
+}
+
+function parseYamlArrayItem(lines: string[]): any {
+  const firstLine = lines[0].trimStart().replace(/^- /, "");
+
+  // オブジェクト形式のアイテム (- key: value)
+  if (firstLine.includes(":")) {
+    const obj: Record<string, any> = {};
+    const keyMatch = firstLine.match(/^(\w[\w_]*)\s*:\s*(.*)/);
+    if (keyMatch) {
+      const key = keyMatch[1];
+      let value = keyMatch[2].trim();
+
+      if (value === "|") {
+        // マルチライン値
+        const contentLines = lines.slice(1).map((l) => l.replace(/^ {6,}/, ""));
+        obj[key] = contentLines.join("\n").trim();
+      } else {
+        obj[key] = value.replace(/^["']|["']$/g, "");
+      }
+
+      // 残りの行もパース
+      for (let i = 1; i < lines.length; i++) {
+        const subMatch = lines[i].trimStart().match(/^(\w[\w_]*)\s*:\s*(.*)/);
+        if (subMatch) {
+          const subKey = subMatch[1];
+          let subValue = subMatch[2].trim();
+          if (subValue === "|") {
+            const subContentLines: string[] = [];
+            for (let j = i + 1; j < lines.length; j++) {
+              const nextMatch = lines[j].trimStart().match(/^(\w[\w_]*)\s*:/);
+              if (nextMatch) break;
+              subContentLines.push(lines[j].replace(/^ {6,}/, ""));
+            }
+            obj[subKey] = subContentLines.join("\n").trim();
+          } else {
+            obj[subKey] = subValue.replace(/^["']|["']$/g, "");
+          }
+        }
+      }
+    }
+    return obj;
+  }
+
+  // 単純な文字列
+  return firstLine.replace(/^["']|["']$/g, "");
+}
+
+function parseYamlObject(lines: string[]): Record<string, any> {
+  const deindented = lines.map((l) => l.replace(/^ {2}/, ""));
+  return parseYaml(deindented.join("\n"));
+}
+
+// --- Markdown → Portable Text 変換 ---
+function markdownToPortableText(markdown: string): any[] {
+  if (!markdown || !markdown.trim()) return [];
+
+  const blocks: any[] = [];
+  const lines = markdown.split("\n");
+  let currentParagraph: string[] = [];
+
+  const flushParagraph = () => {
+    if (currentParagraph.length > 0) {
+      const text = currentParagraph.join("\n").trim();
+      if (text) {
+        blocks.push(createBlock("normal", text));
+      }
+      currentParagraph = [];
+    }
+  };
+
+  for (const line of lines) {
+    // 見出し
+    const h4Match = line.match(/^####\s+(.+)/);
+    if (h4Match) { flushParagraph(); blocks.push(createBlock("h4", h4Match[1])); continue; }
+
+    const h3Match = line.match(/^###\s+(.+)/);
+    if (h3Match) { flushParagraph(); blocks.push(createBlock("h3", h3Match[1])); continue; }
+
+    const h2Match = line.match(/^##\s+(.+)/);
+    if (h2Match) { flushParagraph(); blocks.push(createBlock("h2", h2Match[1])); continue; }
+
+    // 箇条書き
+    const listMatch = line.match(/^(\s*)[-*]\s+(.+)/);
+    if (listMatch) {
+      flushParagraph();
+      blocks.push(createListBlock(listMatch[2], "bullet"));
+      continue;
+    }
+
+    // 番号付きリスト
+    const numListMatch = line.match(/^(\s*)\d+\.\s+(.+)/);
+    if (numListMatch) {
+      flushParagraph();
+      blocks.push(createListBlock(numListMatch[2], "number"));
+      continue;
+    }
+
+    // 空行
+    if (line.trim() === "") {
+      flushParagraph();
+      continue;
+    }
+
+    currentParagraph.push(line);
+  }
+
+  flushParagraph();
+  return blocks;
+}
+
+function createBlock(style: string, text: string): any {
+  return {
+    _type: "block",
+    _key: generateKey(),
+    style,
+    children: parseInlineMarkdown(text),
+    markDefs: [],
+  };
+}
+
+function createListBlock(text: string, listType: "bullet" | "number"): any {
+  return {
+    _type: "block",
+    _key: generateKey(),
+    style: "normal",
+    listItem: listType,
+    level: 1,
+    children: parseInlineMarkdown(text),
+    markDefs: [],
+  };
+}
+
+function parseInlineMarkdown(text: string): any[] {
+  // リンクと太字のパース
+  const spans: any[] = [];
+  const markDefs: any[] = [];
+  let remaining = text;
+
+  // シンプルなアプローチ: リンクと太字を順にパース
+  const parts = remaining.split(/(\[.*?\]\(.*?\)|\*\*.*?\*\*)/);
+
+  for (const part of parts) {
+    // リンク
+    const linkMatch = part.match(/^\[(.*?)\]\((.*?)\)$/);
+    if (linkMatch) {
+      const linkKey = generateKey();
+      markDefs.push({
+        _type: "link",
+        _key: linkKey,
+        href: linkMatch[2],
+      });
+      spans.push({
+        _type: "span",
+        _key: generateKey(),
+        text: linkMatch[1],
+        marks: [linkKey],
+      });
+      continue;
+    }
+
+    // 太字
+    const boldMatch = part.match(/^\*\*(.*?)\*\*$/);
+    if (boldMatch) {
+      spans.push({
+        _type: "span",
+        _key: generateKey(),
+        text: boldMatch[1],
+        marks: ["strong"],
+      });
+      continue;
+    }
+
+    // 通常テキスト
+    if (part) {
+      spans.push({
+        _type: "span",
+        _key: generateKey(),
+        text: part,
+        marks: [],
+      });
+    }
+  }
+
+  // markDefsをブロックに入れるために返す
+  if (spans.length === 0) {
+    spans.push({ _type: "span", _key: generateKey(), text: "", marks: [] });
+  }
+
+  // markDefsをspansの最初の要素に付与（後でブロックレベルで統合）
+  (spans as any).__markDefs = markDefs;
+
+  return spans;
+}
+
+// markDefsをブロックに統合するヘルパー
+function createBlockWithLinks(style: string, text: string): any {
+  const children = parseInlineMarkdown(text);
+  const markDefs = (children as any).__markDefs || [];
+  return {
+    _type: "block",
+    _key: generateKey(),
+    style,
+    children,
+    markDefs,
+  };
+}
+
+let keyCounter = 0;
+function generateKey(): string {
+  return `key${Date.now().toString(36)}${(keyCounter++).toString(36)}`;
+}
+
+// --- メイン処理 ---
+async function migrate() {
+  console.log(`🚀 Training移行開始 (dataset: ${DATASET})`);
+  console.log(`📁 コンテンツディレクトリ: ${CONTENT_DIR}`);
+
+  const trainingDirs = fs.readdirSync(CONTENT_DIR).filter((name) => {
+    return fs.statSync(path.join(CONTENT_DIR, name)).isDirectory();
+  });
+
+  console.log(`📋 ${trainingDirs.length}件のトレーニングを移行します\n`);
+
+  // カテゴリのマッピング（Sanityに既存のcategoryドキュメントを取得）
+  const categories = await client.fetch(`*[_type == "category"]{ _id, title }`);
+  const categoryMap = new Map(categories.map((c: any) => [c.title, c._id]));
+  console.log(`📂 カテゴリ: ${Array.from(categoryMap.keys()).join(", ")}\n`);
+
+  for (const dirName of trainingDirs) {
+    const trainingDir = path.join(CONTENT_DIR, dirName);
+    const indexPath = path.join(trainingDir, "index.md");
+
+    if (!fs.existsSync(indexPath)) {
+      console.warn(`⚠️ ${dirName}: index.md が見つかりません。スキップ`);
+      continue;
+    }
+
+    const indexContent = fs.readFileSync(indexPath, "utf-8");
+    const { frontmatter } = parseFrontmatter(indexContent);
+
+    console.log(`📝 ${frontmatter.title || dirName}`);
+
+    // Training ドキュメント作成（IDにスペース不可のためサニタイズ）
+    const sanitizedDirName = dirName.trim().replace(/[^a-zA-Z0-9_-]/g, "-");
+    const trainingId = `training-${sanitizedDirName}`;
+    const trainingDoc: Record<string, any> = {
+      _id: trainingId,
+      _type: "training",
+      title: frontmatter.title || dirName,
+      slug: { _type: "slug", current: dirName },
+      description: frontmatter.description || "",
+      trainingType: frontmatter.type || "challenge",
+      difficulty: frontmatter.difficulty || "normal",
+      tags: frontmatter.tags || [],
+      isPremium: frontmatter.isPremium || false,
+      orderIndex: frontmatter.order_index || 0,
+      iconImageUrl: frontmatter.icon || undefined,
+      thumbnailUrl: frontmatter.thumbnail || undefined,
+      backgroundSvg: frontmatter.background_svg || undefined,
+      estimatedTotalTime: frontmatter.estimated_total_time || undefined,
+    };
+
+    // カテゴリ参照
+    if (frontmatter.category && categoryMap.has(frontmatter.category)) {
+      trainingDoc.category = {
+        _type: "reference",
+        _ref: categoryMap.get(frontmatter.category),
+      };
+    }
+
+    // グラデーション
+    if (frontmatter.fallback_gradient) {
+      trainingDoc.fallbackGradient = {
+        from: frontmatter.fallback_gradient.from || "",
+        via: frontmatter.fallback_gradient.via || "",
+        to: frontmatter.fallback_gradient.to || "",
+      };
+    }
+
+    // スキル
+    if (frontmatter.skills && Array.isArray(frontmatter.skills)) {
+      trainingDoc.skills = frontmatter.skills.map((s: any) => ({
+        _key: generateKey(),
+        title: s.title || "",
+        description: s.description || "",
+        referenceLink: s.reference_link || undefined,
+      }));
+    }
+
+    // ガイド
+    if (frontmatter.guide) {
+      trainingDoc.guide = {
+        title: frontmatter.guide.title || "",
+        description: frontmatter.guide.description || "",
+        lesson: frontmatter.guide.lesson
+          ? {
+              title: frontmatter.guide.lesson.title || "",
+              image: frontmatter.guide.lesson.image || undefined,
+              description: frontmatter.guide.lesson.description || "",
+              link: frontmatter.guide.lesson.link || undefined,
+            }
+          : undefined,
+        steps: frontmatter.guide.steps
+          ? frontmatter.guide.steps.map((s: any) => ({
+              _key: generateKey(),
+              title: s.title || "",
+              description: s.description || "",
+            }))
+          : [],
+      };
+    }
+
+    // 1. まずトレーニングを作成（タスク参照なし）
+    trainingDoc.tasks = [];
+    await client.createOrReplace(trainingDoc);
+    console.log(`   ✅ トレーニング作成: ${trainingId}`);
+
+    // 2. タスクを作成
+    const tasksDir = path.join(trainingDir, "tasks");
+    const taskRefs: any[] = [];
+
+    if (fs.existsSync(tasksDir)) {
+      const taskDirs = fs.readdirSync(tasksDir).filter((name) => {
+        return fs.statSync(path.join(tasksDir, name)).isDirectory();
+      });
+
+      for (const taskDirName of taskDirs) {
+        const contentPath = path.join(tasksDir, taskDirName, "content.md");
+        if (!fs.existsSync(contentPath)) continue;
+
+        const taskContent = fs.readFileSync(contentPath, "utf-8");
+        const { frontmatter: taskFm, body: taskBody } = parseFrontmatter(taskContent);
+
+        const taskSlug = taskFm.slug || taskDirName;
+        const sanitizedTaskSlug = String(taskSlug).trim().replace(/[^a-zA-Z0-9_-]/g, "-");
+        const taskId = `trainingTask-${sanitizedDirName}-${sanitizedTaskSlug}`;
+
+        console.log(`   📋 タスク: ${taskFm.title || taskDirName}`);
+
+        // セクションをPortable Textに変換
+        const sections: any[] = [];
+        if (taskFm.sections && Array.isArray(taskFm.sections)) {
+          for (const section of taskFm.sections) {
+            sections.push({
+              _key: generateKey(),
+              sectionTitle: section.title || "",
+              sectionType: section.type || "regular",
+              content: section.content
+                ? markdownToPortableText(section.content)
+                : [],
+            });
+          }
+        }
+
+        // 本文もセクションとして追加（フロントマター以降のMarkdown）
+        if (taskBody && taskBody.trim()) {
+          sections.push({
+            _key: generateKey(),
+            sectionTitle: "本文",
+            sectionType: "regular",
+            content: markdownToPortableText(taskBody),
+          });
+        }
+
+        const taskDoc: Record<string, any> = {
+          _id: taskId,
+          _type: "trainingTask",
+          title: taskFm.title || taskDirName,
+          slug: { _type: "slug", current: taskSlug },
+          description: taskFm.description || "",
+          orderIndex: taskFm.order_index || 1,
+          isPremium: taskFm.is_premium || false,
+          category: taskFm.category || undefined,
+          tags: taskFm.tags || [],
+          videoFull: taskFm.video_member || taskFm.video_full || undefined,
+          videoPreview: taskFm.video_free || taskFm.video_preview || undefined,
+          previewSec: taskFm.preview_sec || undefined,
+          training: { _type: "reference", _ref: trainingId },
+          sections,
+        };
+
+        await client.createOrReplace(taskDoc);
+        console.log(`   ✅ タスク作成: ${taskId}`);
+
+        taskRefs.push({
+          _type: "reference",
+          _ref: taskId,
+          _key: generateKey(),
+        });
+      }
+    }
+
+    // 3. トレーニングにタスク参照を追加
+    if (taskRefs.length > 0) {
+      await client.patch(trainingId).set({ tasks: taskRefs }).commit();
+      console.log(`   ✅ タスク参照追加: ${taskRefs.length}件`);
+    }
+
+    console.log(`✅ 完了: ${frontmatter.title || dirName}\n`);
+  }
+
+  console.log("🎉 移行完了！");
+}
+
+migrate().catch((err) => {
+  console.error("❌ 移行エラー:", err);
+  process.exit(1);
+});

--- a/sanity-studio/scripts/migrate-training.ts
+++ b/sanity-studio/scripts/migrate-training.ts
@@ -63,7 +63,7 @@ function parseYaml(yaml: string): Record<string, any> {
     }
 
     const key = keyMatch[1];
-    let value = keyMatch[2].trim();
+    const value = keyMatch[2].trim();
 
     // 配列 (インライン)
     if (value.startsWith("[")) {
@@ -152,7 +152,7 @@ function parseYamlArrayItem(lines: string[]): any {
     const keyMatch = firstLine.match(/^(\w[\w_]*)\s*:\s*(.*)/);
     if (keyMatch) {
       const key = keyMatch[1];
-      let value = keyMatch[2].trim();
+      const value = keyMatch[2].trim();
 
       if (value === "|") {
         // マルチライン値
@@ -167,7 +167,7 @@ function parseYamlArrayItem(lines: string[]): any {
         const subMatch = lines[i].trimStart().match(/^(\w[\w_]*)\s*:\s*(.*)/);
         if (subMatch) {
           const subKey = subMatch[1];
-          let subValue = subMatch[2].trim();
+          const subValue = subMatch[2].trim();
           if (subValue === "|") {
             const subContentLines: string[] = [];
             for (let j = i + 1; j < lines.length; j++) {
@@ -278,7 +278,7 @@ function parseInlineMarkdown(text: string): any[] {
   // リンクと太字のパース
   const spans: any[] = [];
   const markDefs: any[] = [];
-  let remaining = text;
+  const remaining = text;
 
   // シンプルなアプローチ: リンクと太字を順にパース
   const parts = remaining.split(/(\[.*?\]\(.*?\)|\*\*.*?\*\*)/);

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -721,3 +721,153 @@ export async function getUserQuestions(userId: string): Promise<UserQuestion[]> 
   return client.fetch<UserQuestion[]>(query, { userId });
 }
 
+// ===== Training 関連クエリ =====
+
+interface SanityTrainingListItem {
+  _id: string;
+  title: string;
+  slug: string;
+  description: string;
+  type: string;
+  difficulty: string;
+  category: string;
+  tags: string[];
+  isPremium: boolean;
+  orderIndex: number;
+  iconImageUrl: string;
+  thumbnailUrl: string;
+  backgroundSvg: string;
+  fallbackGradient: { from: string; via: string; to: string };
+  estimatedTotalTime: string;
+  task_count: number;
+}
+
+interface SanityTrainingDetail extends SanityTrainingListItem {
+  skills: { title: string; description: string; referenceLink?: string }[];
+  guide: any;
+  tasks: SanityTrainingTask[];
+}
+
+interface SanityTrainingTask {
+  _id: string;
+  title: string;
+  slug: string;
+  description: string;
+  orderIndex: number;
+  isPremium: boolean;
+  category: string;
+  tags: string[];
+  videoFull: string;
+  videoPreview: string;
+  previewSec: number;
+  sections: any[];
+  training: { _id: string; title: string; slug: string; type: string };
+  allTasks: { _id: string; title: string; slug: string; orderIndex: number }[];
+}
+
+/**
+ * トレーニング一覧を取得
+ */
+export async function getTrainings(): Promise<SanityTrainingListItem[]> {
+  const query = `
+    *[_type == "training"] | order(orderIndex asc) {
+      _id,
+      title,
+      "slug": slug.current,
+      description,
+      "type": trainingType,
+      difficulty,
+      "category": category->title,
+      tags,
+      isPremium,
+      orderIndex,
+      iconImageUrl,
+      thumbnailUrl,
+      backgroundSvg,
+      fallbackGradient,
+      estimatedTotalTime,
+      "task_count": count(tasks)
+    }
+  `;
+  return client.fetch(query);
+}
+
+/**
+ * トレーニング詳細を取得
+ */
+export async function getTrainingDetail(slug: string): Promise<SanityTrainingDetail | null> {
+  const query = `
+    *[_type == "training" && slug.current == $slug][0] {
+      _id,
+      title,
+      "slug": slug.current,
+      description,
+      "type": trainingType,
+      difficulty,
+      "category": category->title,
+      tags,
+      isPremium,
+      iconImageUrl,
+      thumbnailUrl,
+      backgroundSvg,
+      fallbackGradient,
+      estimatedTotalTime,
+      skills,
+      guide,
+      "tasks": tasks[]-> {
+        _id,
+        title,
+        "slug": slug.current,
+        description,
+        orderIndex,
+        isPremium,
+        category,
+        tags,
+        videoFull,
+        videoPreview
+      } | order(orderIndex asc)
+    }
+  `;
+  return client.fetch(query, { slug });
+}
+
+/**
+ * トレーニングタスク詳細を取得
+ */
+export async function getTrainingTaskDetail(trainingSlug: string, taskSlug: string): Promise<SanityTrainingTask | null> {
+  const query = `
+    *[_type == "trainingTask" && slug.current == $taskSlug && training->slug.current == $trainingSlug][0] {
+      _id,
+      title,
+      "slug": slug.current,
+      description,
+      orderIndex,
+      isPremium,
+      category,
+      tags,
+      videoFull,
+      videoPreview,
+      previewSec,
+      sections[] {
+        _key,
+        sectionTitle,
+        sectionType,
+        content
+      },
+      "training": training-> {
+        _id,
+        title,
+        "slug": slug.current,
+        "type": trainingType
+      },
+      "allTasks": training->tasks[]-> {
+        _id,
+        title,
+        "slug": slug.current,
+        orderIndex
+      } | order(orderIndex asc)
+    }
+  `;
+  return client.fetch(query, { trainingSlug, taskSlug });
+}
+

--- a/src/pages/Training/TaskDetailPage.tsx
+++ b/src/pages/Training/TaskDetailPage.tsx
@@ -8,13 +8,14 @@ import TaskNavigation from './TaskNavigation';
 import TaskVideo from '@/components/training/TaskVideo';
 import ErrorDisplay from '@/components/common/ErrorBoundary';
 import { useTaskDetail } from '@/hooks/useTrainingCache';
-import { TaskFrontmatter } from '@/types/training';
+import { TaskFrontmatter, SanitySection } from '@/types/training';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { parseContentSections, type ContentSectionData, type StructuredSection } from '@/utils/parseContentSections';
 import ContentSection from '@/components/training/ContentSection';
 import DesignSolutionSection from '@/components/training/DesignSolutionSection';
 import NavigationHeader from '@/components/training/NavigationHeader';
 import { BackButton } from '@/components/common/BackButton';
+import PortableTextRenderer from '@/components/common/PortableTextRenderer';
 
 /**
  * 安全にbooleanを変換するヘルパー関数
@@ -66,29 +67,6 @@ const TaskDetailPage = () => {
     return <Navigate to="/training" replace />;
   }
   const hasPremiumAccess = isSubscribed && hasMemberAccess;
-
-  // デバッグログを強化
-  console.log('TaskDetailPage - アクセス権情報:', { 
-    isSubscribed,
-    hasMemberAccess,
-    hasPremiumAccess,
-    taskIsPremium: task?.is_premium,
-    trainingSlug,
-    taskSlug,
-    userAuthenticated: !!user,
-    taskDataExists: !!task,
-    taskTitle: task?.title,
-    taskContentLength: task?.content?.length || 0
-  });
-
-  // フェーズ2: 有料コンテンツテスト用ログ追加
-  if (task?.is_premium) {
-    console.log('TaskDetailPage - 有料コンテンツ検出:', {
-      taskTitle: task.title,
-      userCanAccess: hasPremiumAccess,
-      needsUpgrade: !hasPremiumAccess
-    });
-  }
 
   if (isLoading) {
     return (
@@ -265,18 +243,6 @@ const TaskDetailPage = () => {
       description: safeStringConvert(task.description),
     };
 
-    console.log('TaskDetailPage - フロントマター変換完了:', {
-      originalData: {
-        is_premium: task.is_premium,
-        order_index: task.order_index,
-        preview_sec: task.preview_sec
-      },
-      convertedData: {
-        is_premium: frontmatter.is_premium,
-        order_index: frontmatter.order_index,
-        preview_sec: frontmatter.preview_sec
-      }
-    });
   } catch (conversionError) {
     console.error('TaskDetailPage - フロントマター変換エラー:', conversionError);
     // エラー時のフォールバック値
@@ -300,36 +266,17 @@ const TaskDetailPage = () => {
   const hasValidVideo = (frontmatter.video_preview && frontmatter.video_preview.trim()) || 
                         (frontmatter.video_full && frontmatter.video_full.trim());
 
-  // フェーズ2: 動画とコンテンツアクセスログ
-  console.log('TaskDetailPage - コンテンツアクセス詳細:', {
-    hasValidVideo,
-    videoFull: !!frontmatter.video_full,
-    videoPreview: !!frontmatter.video_preview,
-    contentLength: task.content?.length || 0,
-    renderMarkdown: true
-  });
+  // Sanity Portable Text セクション（新方式）
+  const sanitySections: SanitySection[] | undefined = task?.sanitySections;
+  const hasSanitySections = sanitySections && sanitySections.length > 0;
 
-  // Step 6: 最終統合 - 構造化コンテンツ対応版
+  // 旧方式: Markdown コンテンツ（フォールバック）
   let contentSections: ContentSectionData[] = [];
-  const hasValidContent = task && task.content && typeof task.content === 'string' && task.content.trim();
-  
-  // 構造化セクションデータの確認（将来的にフロントマターから取得）
-  const structuredSections: StructuredSection[] | undefined = (task as any)?.sections;
-  
+  const hasValidContent = !hasSanitySections && task && task.content && typeof task.content === 'string' && task.content.trim();
+
   if (hasValidContent) {
-    // 構造化データを優先的に使用し、フォールバックでマークダウン解析
+    const structuredSections: StructuredSection[] | undefined = (task as any)?.sections;
     contentSections = parseContentSections(task.content, structuredSections);
-    console.log('✅ 最終統合 - 解析されたセクション数:', contentSections.length);
-    console.log('✅ 最終統合 - セクション構成:', contentSections.map(s => ({ title: s.title, type: s.type })));
-    console.log('✅ 最終統合 - 構造化データ使用:', !!structuredSections?.length);
-  } else {
-    console.warn('⚠️ 最終統合 - コンテンツが無効またはない:', { 
-      hasTask: !!task, 
-      hasContent: !!(task?.content), 
-      contentType: typeof task?.content,
-      contentLength: task?.content?.length || 0,
-      hasStructuredSections: !!structuredSections?.length
-    });
   }
 
   return (
@@ -395,21 +342,47 @@ const TaskDetailPage = () => {
                   </div>
                 )}
 
-                 {/* Step 4-5: 構造化コンテンツセクション表示（プレミアムコンテンツ対応） */}
+                 {/* コンテンツセクション表示 */}
                  <div className="mb-8">
-                   {hasValidContent && contentSections.length > 0 ? (
+                   {hasSanitySections ? (
+                     /* Sanity Portable Text セクション */
+                     sanitySections.map((section) => (
+                       <div key={section._key} className="mb-6">
+                         {section.sectionType === 'premium-only' && !hasPremiumAccess ? (
+                           <div className="border-2 border-orange-200 rounded-lg p-6 bg-orange-50">
+                             <div className="flex items-center gap-3 mb-3">
+                               <span className="text-2xl">🔒</span>
+                               <h3 className="text-lg font-bold text-orange-800">{section.sectionTitle}</h3>
+                             </div>
+                             <div className="text-orange-600 text-sm mb-4">
+                               このセクションはメンバー限定コンテンツです。
+                             </div>
+                             <button
+                               onClick={() => navigate('/training/plan')}
+                               className="bg-orange-600 hover:bg-orange-700 text-white px-4 py-2 rounded-lg text-sm transition-colors"
+                             >
+                               プランを確認
+                             </button>
+                           </div>
+                         ) : (
+                           <div>
+                             {section.sectionTitle && (
+                               <h2 className="text-xl font-bold text-[#1d382f] mb-4">{section.sectionTitle}</h2>
+                             )}
+                             <PortableTextRenderer value={section.content || []} />
+                           </div>
+                         )}
+                       </div>
+                     ))
+                   ) : hasValidContent && contentSections.length > 0 ? (
+                     /* 旧Markdownフォールバック */
                      contentSections.map((section, index) => (
                        <div key={index} className="mb-6">
                          {section.type === 'design-solution' ? (
-                           <DesignSolutionSection 
-                             content={section.content}
-                           />
+                           <DesignSolutionSection content={section.content} />
                          ) : section.type === 'premium-only' ? (
                            hasPremiumAccess ? (
-                             <ContentSection 
-                               title={section.title}
-                               content={section.content}
-                             />
+                             <ContentSection title={section.title} content={section.content} />
                            ) : (
                              <div className="border-2 border-orange-200 rounded-lg p-6 bg-orange-50">
                                <div className="flex items-center gap-3 mb-3">
@@ -428,10 +401,7 @@ const TaskDetailPage = () => {
                              </div>
                            )
                          ) : (
-                           <ContentSection 
-                             title={section.title}
-                             content={section.content}
-                           />
+                           <ContentSection title={section.title} content={section.content} />
                          )}
                        </div>
                      ))

--- a/src/services/training/task-detail.ts
+++ b/src/services/training/task-detail.ts
@@ -1,196 +1,55 @@
 
-import { supabase } from "@/integrations/supabase/client";
 import { TaskDetailData } from "@/types/training";
+import { getTrainingTaskDetail as fetchFromSanity } from "@/lib/sanity";
 import { TrainingError } from "@/utils/errors";
-import { handleEdgeFunctionError, validateEdgeFunctionResponse } from "./error-handlers";
-import { getLocalTaskContent } from "./local-content-fallback";
 
 /**
- * 安全にプロパティを取得するヘルパー関数
- */
-const safeGet = (obj: any, path: string, defaultValue: any = null): any => {
-  try {
-    return path.split('.').reduce((current, key) => current && current[key], obj) ?? defaultValue;
-  } catch (error) {
-    console.warn(`safeGet: ${path} の取得に失敗:`, error);
-    return defaultValue;
-  }
-};
-
-/**
- * レスポンスデータの検証と変換
- */
-const validateAndTransformResponse = (responseData: any, trainingSlug: string, taskSlug: string): TaskDetailData => {
-  if (!responseData) {
-    throw new TrainingError('レスポンスデータが空です', 'EMPTY_RESPONSE');
-  }
-
-  // 必須フィールドの検証
-  const content = safeGet(responseData, 'content', '');
-  const meta = safeGet(responseData, 'meta', {});
-  
-  if (!content && typeof content !== 'string') {
-    console.warn('validateAndTransformResponse: コンテンツが文字列ではありません');
-  }
-
-  if (!meta || typeof meta !== 'object') {
-    console.warn('validateAndTransformResponse: メタデータが無効です');
-  }
-
-  // 安全な型変換
-  const isPremium = (() => {
-    const rawValue = safeGet(responseData, 'isPremium', false);
-    if (typeof rawValue === 'boolean') return rawValue;
-    if (rawValue === 'true') return true;
-    if (rawValue === 'false') return false;
-    return Boolean(rawValue);
-  })();
-
-  const orderIndex = (() => {
-    const rawValue = safeGet(meta, 'order_index', 1);
-    if (typeof rawValue === 'number') return rawValue;
-    const parsed = parseInt(rawValue, 10);
-    return isNaN(parsed) ? 1 : parsed;
-  })();
-
-  const previewSec = (() => {
-    const rawValue = safeGet(meta, 'preview_sec', 30);
-    if (typeof rawValue === 'number') return rawValue;
-    const parsed = parseInt(rawValue, 10);
-    return isNaN(parsed) ? 30 : parsed;
-  })();
-
-  // レスポンス形式を TaskDetailData 型に合わせて変換
-  const taskDetail: TaskDetailData = {
-    id: `${trainingSlug}-${taskSlug}`,
-    slug: taskSlug,
-    title: safeGet(meta, 'title', taskSlug),
-    content: content,
-    is_premium: isPremium,
-    order_index: orderIndex,
-    training_id: trainingSlug,
-    created_at: new Date().toISOString(),
-    video_full: safeGet(meta, 'video_full'),
-    video_preview: safeGet(meta, 'video_preview'),
-    preview_sec: previewSec,
-    trainingTitle: safeGet(meta, 'training_title', trainingSlug),
-    trainingSlug: trainingSlug,
-    next_task: safeGet(meta, 'next_task'),
-    prev_task: safeGet(meta, 'prev_task'),
-    isPremiumCut: safeGet(responseData, 'showPremiumBanner', false),
-    hasAccess: safeGet(responseData, 'hasAccess', true),
-    // Storage front-matterから取得した新しいフィールドを追加
-    estimated_time: safeGet(meta, 'estimated_time'),
-    difficulty: safeGet(meta, 'difficulty'),
-    description: safeGet(meta, 'description')
-  };
-
-  console.log('validateAndTransformResponse - 変換完了:', {
-    inputKeys: Object.keys(responseData),
-    metaKeys: Object.keys(meta),
-    outputKeys: Object.keys(taskDetail),
-    isPremium: {
-      raw: safeGet(responseData, 'isPremium'),
-      converted: isPremium
-    }
-  });
-
-  return taskDetail;
-};
-
-/**
- * タスク詳細を取得（Storage + Edge Functionベース）
+ * タスク詳細を取得（Sanityベース）
  */
 export const getTrainingTaskDetail = async (trainingSlug: string, taskSlug: string): Promise<TaskDetailData> => {
-  console.log(`🚀 タスク詳細取得開始: ${trainingSlug}/${taskSlug}`);
-  console.log(`📊 デバッグ情報:`, {
-    trainingSlug,
-    taskSlug,
-    timestamp: new Date().toISOString(),
-    userAgent: navigator.userAgent
-  });
-  
+  if (!trainingSlug || !taskSlug) {
+    throw new TrainingError("トレーニングスラッグとタスクスラッグが必要です", "INVALID_REQUEST", 400);
+  }
+
   try {
-    if (!trainingSlug || !taskSlug) {
-      throw new TrainingError('トレーニングスラッグとタスクスラッグが必要です', 'INVALID_REQUEST', 400);
-    }
-    
-    if (typeof trainingSlug !== 'string' || typeof taskSlug !== 'string') {
-      throw new TrainingError('スラッグは文字列である必要があります', 'INVALID_REQUEST', 400);
-    }
-    
-    // 新しいEdge Functionを呼び出し
-    console.log(`📡 Edge Function呼び出し:`, {
-      functionName: 'get-training-content',
-      requestBody: {
-        trainingSlug: trainingSlug.trim(),
-        taskSlug: taskSlug.trim()
-      }
-    });
-    
-    const { data, error } = await supabase.functions.invoke('get-training-content', {
-      body: {
-        trainingSlug: trainingSlug.trim(),
-        taskSlug: taskSlug.trim()
-      }
-    });
+    const data = await fetchFromSanity(trainingSlug, taskSlug);
 
-    console.log('📥 Edge Function レスポンス:', { 
-      hasData: !!data, 
-      hasError: !!error,
-      dataKeys: data ? Object.keys(data) : [],
-      errorDetails: error,
-      errorType: error?.name,
-      errorMessage: error?.message 
-    });
-
-    // エラーがある場合、まずローカルフォールバックを試行
-    if (error) {
-      console.log('🔄 Edge Functionエラー検出 - ローカルフォールバックを優先実行');
-      
-      try {
-        const localTaskDetail = await getLocalTaskContent(trainingSlug, taskSlug);
-        if (localTaskDetail) {
-          console.log('✅ ローカルフォールバック成功 - Edge Functionエラーを回避');
-          return localTaskDetail;
-        } else {
-          console.log('❌ ローカルフォールバック失敗 - 元のエラーを処理');
-        }
-      } catch (fallbackError) {
-        console.error('❌ ローカルフォールバック処理中エラー:', fallbackError);
-      }
-      
-      // ローカルフォールバック失敗時のみエラーハンドリング実行
-      handleEdgeFunctionError(error, 'タスク詳細の取得に失敗しました');
+    if (!data) {
+      throw new TrainingError("タスクが見つかりません", "NOT_FOUND", 404);
     }
 
-    // Edge Function成功時の通常処理
-    const responseData = validateEdgeFunctionResponse(data, 'タスク詳細');
-    const taskDetail = validateAndTransformResponse(responseData, trainingSlug, taskSlug);
-    
-    return taskDetail;
-    
+    // 前後のタスクを算出
+    const allTasks = data.allTasks || [];
+    const currentIndex = allTasks.findIndex((t: any) => t.slug === taskSlug);
+    const prevTask = currentIndex > 0 ? allTasks[currentIndex - 1].slug : null;
+    const nextTask = currentIndex < allTasks.length - 1 ? allTasks[currentIndex + 1].slug : null;
+
+    return {
+      id: data._id,
+      slug: data.slug,
+      title: data.title,
+      content: "", // Portable Textはsectionsで提供
+      is_premium: data.isPremium || false,
+      order_index: data.orderIndex ?? 1,
+      training_id: data.training?._id || "",
+      created_at: null,
+      video_full: data.videoFull,
+      video_preview: data.videoPreview,
+      preview_sec: data.previewSec,
+      trainingTitle: data.training?.title || "",
+      trainingSlug: data.training?.slug || trainingSlug,
+      trainingType: data.training?.type,
+      next_task: nextTask,
+      prev_task: prevTask,
+      isPremiumCut: false,
+      hasAccess: true,
+      description: data.description,
+      // Sanity Portable Text セクション
+      sanitySections: data.sections || [],
+    };
   } catch (err) {
-    console.error('getTrainingTaskDetail 最終catch - 予期しないエラー:', err);
-    
-    // 最後の試行としてローカルフォールバック実行
-    console.log('🔄 最終フォールバック試行...');
-    try {
-      const localTaskDetail = await getLocalTaskContent(trainingSlug, taskSlug);
-      if (localTaskDetail) {
-        console.log('✅ 最終フォールバック成功');
-        return localTaskDetail;
-      }
-    } catch (fallbackError) {
-      console.error('❌ 最終フォールバックも失敗:', fallbackError);
-    }
-    
-    // カスタムエラーは再スロー
-    if (err instanceof TrainingError) {
-      throw err;
-    }
-    
-    console.error('getTrainingTaskDetail 全ての試行が失敗:', err);
-    throw new TrainingError('タスク詳細の取得中に予期しないエラーが発生しました', 'UNKNOWN_ERROR');
+    if (err instanceof TrainingError) throw err;
+    console.error("getTrainingTaskDetail エラー:", err);
+    throw new TrainingError("タスク詳細の取得中にエラーが発生しました", "UNKNOWN_ERROR");
   }
 };

--- a/src/services/training/training-detail.ts
+++ b/src/services/training/training-detail.ts
@@ -1,37 +1,56 @@
 
-import { supabase } from "@/integrations/supabase/client";
 import { TrainingDetailData } from "@/types/training";
+import { getTrainingDetail as fetchFromSanity } from "@/lib/sanity";
 import { TrainingError } from "@/utils/errors";
-import { handleEdgeFunctionError, validateEdgeFunctionResponse } from "./error-handlers";
 
 /**
- * トレーニング詳細情報を取得（Storageベース）
+ * トレーニング詳細情報を取得（Sanityベース）
  */
 export const getTrainingDetail = async (slug: string): Promise<TrainingDetailData> => {
+  if (!slug || slug.trim() === "") {
+    throw new TrainingError("トレーニングスラッグが指定されていません", "INVALID_REQUEST", 400);
+  }
+
   try {
-    console.log(`Edge Functionからトレーニング詳細を取得: ${slug}`);
-    
-    if (!slug || slug.trim() === '') {
-      throw new TrainingError('トレーニングスラッグが指定されていません', 'INVALID_REQUEST', 400);
-    }
-    
-    const { data, error } = await supabase.functions.invoke('get-training-detail', {
-      body: { slug }
-    });
+    const data = await fetchFromSanity(slug);
 
-    if (error) {
-      handleEdgeFunctionError(error, 'トレーニング詳細の取得に失敗しました');
+    if (!data) {
+      throw new TrainingError("トレーニングが見つかりません", "NOT_FOUND", 404);
     }
 
-    return validateEdgeFunctionResponse(data, 'トレーニング詳細') as TrainingDetailData;
-    
+    return {
+      id: data._id,
+      slug: data.slug,
+      title: data.title,
+      description: data.description || "",
+      type: data.type || "challenge",
+      difficulty: data.difficulty || "normal",
+      tags: data.tags || [],
+      tasks: (data.tasks || []).map((task: any) => ({
+        id: task._id,
+        training_id: data._id,
+        slug: task.slug,
+        title: task.title,
+        order_index: task.orderIndex ?? 1,
+        is_premium: task.isPremium || false,
+        video_full: task.videoFull,
+        video_preview: task.videoPreview,
+        category: task.category,
+        tags: task.tags || [],
+        description: task.description,
+      })),
+      skills: data.skills,
+      guide: data.guide,
+      thumbnailImage: data.thumbnailUrl,
+      iconImageUrl: data.iconImageUrl,
+      backgroundSvg: data.backgroundSvg,
+      fallbackGradient: data.fallbackGradient,
+      estimatedTotalTime: data.estimatedTotalTime,
+      has_premium_content: (data.tasks || []).some((t: any) => t.isPremium),
+    };
   } catch (err) {
-    // カスタムエラーは再スロー
-    if (err instanceof TrainingError) {
-      throw err;
-    }
-    
-    console.error('getTrainingDetail 予期しないエラー:', err);
-    throw new TrainingError('トレーニング詳細の取得中に予期しないエラーが発生しました', 'UNKNOWN_ERROR');
+    if (err instanceof TrainingError) throw err;
+    console.error("getTrainingDetail エラー:", err);
+    throw new TrainingError("トレーニング詳細の取得中にエラーが発生しました", "UNKNOWN_ERROR");
   }
 };

--- a/src/services/training/training-list.ts
+++ b/src/services/training/training-list.ts
@@ -1,47 +1,33 @@
 
-import { supabase } from "@/integrations/supabase/client";
 import { Training } from "@/types/training";
-import { TrainingError } from "@/utils/errors";
-import { handleEdgeFunctionError, validateEdgeFunctionResponse } from "./error-handlers";
+import { getTrainings as fetchTrainingsFromSanity } from "@/lib/sanity";
 
 /**
- * トレーニング一覧を取得（Storageベース）
+ * トレーニング一覧を取得（Sanityベース）
  */
 export const getTrainings = async (): Promise<Training[]> => {
   try {
-    const { data, error } = await supabase.functions.invoke('get-training-list', {
-      body: {}
-    });
+    const data = await fetchTrainingsFromSanity();
 
-    if (error) {
-      handleEdgeFunctionError(error, 'トレーニング一覧の取得に失敗しました');
-    }
-
-    const result = validateEdgeFunctionResponse(data, 'トレーニング一覧');
-    
-    return result;
-    
+    return data.map((item: any) => ({
+      id: item._id,
+      slug: item.slug,
+      title: item.title,
+      description: item.description || "",
+      type: item.type || "challenge",
+      difficulty: item.difficulty || "normal",
+      tags: item.tags || [],
+      category: item.category,
+      isPremium: item.isPremium || false,
+      icon: item.iconImageUrl,
+      thumbnailImage: item.thumbnailUrl,
+      backgroundImage: item.backgroundSvg,
+      estimated_total_time: item.estimatedTotalTime,
+      task_count: item.task_count ?? 0,
+      isFree: !item.isPremium,
+    }));
   } catch (err) {
-    // カスタムエラーは再スロー
-    if (err instanceof TrainingError) {
-      throw err;
-    }
-    
-    console.error('getTrainings 予期しないエラー:', err);
-    
-    // フォールバック: ダミーデータを返す
-    return [
-      {
-        id: "todo-app-1",
-        slug: "todo-app",
-        title: "Todo アプリ UI 制作",
-        description: "実践的な Todo アプリの UI デザインを学ぶ",
-        type: "challenge" as 'challenge',
-        difficulty: "normal",
-        tags: ["ui", "todo", "実践"],
-        icon: "📱",
-        thumbnailImage: 'https://source.unsplash.com/random/200x100'
-      }
-    ];
+    console.error("getTrainings エラー:", err);
+    return [];
   }
 };

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -59,6 +59,16 @@ export interface TaskDetailData {
   estimated_time?: string;
   difficulty?: string;
   description?: string;
+  // Sanity Portable Text セクション
+  sanitySections?: SanitySection[];
+  trainingType?: string;
+}
+
+export interface SanitySection {
+  _key: string;
+  sectionTitle: string;
+  sectionType: 'regular' | 'design-solution' | 'premium-only';
+  content: import('@portabletext/types').PortableTextBlock[];
 }
 
 export interface TrainingDetailData {
@@ -70,10 +80,15 @@ export interface TrainingDetailData {
   difficulty: string;
   tags: string[];
   tasks: Task[];
-  skills?: string[];
+  skills?: SkillData[];
+  guide?: GuideData;
   prerequisites?: string[];
   has_premium_content?: boolean;
   thumbnailImage?: string;
+  iconImageUrl?: string;
+  backgroundSvg?: string;
+  fallbackGradient?: { from: string; via: string; to: string };
+  estimatedTotalTime?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- /training をSupabase Storage + Edge FunctionsからSanity CMSに完全移行
- Sanityスキーマ（training, trainingTask）を新規作成
- 13トレーニング+13タスクのコンテンツをSanityに投入済み（production/development両方）
- フロントエンドをSanity GROQクエリ直接取得に変更
- TaskDetailPageをPortable Textレンダリングに対応

## Test plan
- [x] `/training` 一覧ページに13件表示確認
- [x] `/training/{slug}` 詳細ページにタスク一覧・skills・guide表示確認
- [x] `/training/{slug}/{taskSlug}` タスク詳細にPortable Textコンテンツ表示確認
- [ ] Phase 4: Edge Functions・ローカルMarkdown削除（動作確認後に実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)