### PR TITLE
perf: 記事ページのサイドナビを layout 化して右側だけ切り替わる体験に（BON-330）

### DIFF
--- a/src/app/articles/[slug]/layout.tsx
+++ b/src/app/articles/[slug]/layout.tsx
@@ -1,0 +1,64 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { getArticleWithContext } from "@/lib/sanity";
+import { getLessonProgress, getLessonStatus } from "@/lib/services/progress";
+import ArticleDetailClient from "./ArticleDetailClient";
+
+// ISR: 1時間キャッシュ（ユーザー固有データはレッスンID単位で再フェッチ）
+export const revalidate = 3600;
+
+interface LayoutProps {
+  params: Promise<{ slug: string }>;
+  children: React.ReactNode;
+}
+
+/**
+ * Article 詳細ページのレイアウト
+ *
+ * サイドナビゲーションをここで描画することで、同じレッスン内の記事間で
+ * 別記事へ遷移してもサイドナビのクライアント状態（開閉・スクロール位置・進捗）が
+ * 保持され、「右側のコンテンツだけ切り替わる」体験を実現する。
+ *
+ * lessonId を ArticleDetailClient の key にすることで、別レッスンへ遷移した
+ * 場合のみサイドナビが remount され、楽観的進捗が新レッスン用に初期化される。
+ */
+export default async function ArticleDetailLayout({ params, children }: LayoutProps) {
+  const { slug } = await params;
+  const article = await getArticleWithContext(slug);
+
+  if (!article) {
+    notFound();
+  }
+
+  // lesson 全体の記事 ID 一覧を集める（楽観的 UI 用の初期値計算に使う）
+  const allLessonArticleIds: string[] = [];
+  if (article.lessonInfo?.quests) {
+    for (const quest of article.lessonInfo.quests) {
+      for (const art of quest.articles) {
+        allLessonArticleIds.push(art._id);
+      }
+    }
+  }
+  const lessonId = article.lessonInfo?._id || "";
+
+  // レッスン進捗・status を並列取得
+  const [lessonProgress, lessonStatus] = await Promise.all([
+    lessonId && allLessonArticleIds.length > 0
+      ? getLessonProgress(lessonId, allLessonArticleIds)
+      : Promise.resolve(null),
+    lessonId ? getLessonStatus(lessonId) : Promise.resolve("not_started" as const),
+  ]);
+
+  const initialCompletedArticleIds = lessonProgress?.completedArticleIds ?? [];
+
+  return (
+    <ArticleDetailClient
+      key={lessonId || slug}
+      article={article}
+      initialCompletedArticleIds={initialCompletedArticleIds}
+      initialLessonStatus={lessonStatus}
+    >
+      {children}
+    </ArticleDetailClient>
+  );
+}

--- a/src/app/articles/[slug]/loading.tsx
+++ b/src/app/articles/[slug]/loading.tsx
@@ -2,29 +2,34 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * 記事詳細ページのローディングUI
+ *
+ * layout.tsx でサイドナビが描画されたあと、main 領域の位置にだけ表示される。
+ * （サイドナビは記事間遷移で保持されるため、loading 時には触れない）
  */
 export default function ArticleDetailLoading() {
   return (
-    <div className="min-h-screen">
-      <div className="max-w-[800px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
-        {/* Article header skeleton */}
-        <div className="mb-8">
-          <Skeleton className="h-4 w-32 mb-3" />
-          <Skeleton className="h-8 w-3/4 mb-4" />
-          <Skeleton className="w-full aspect-video rounded-lg" />
-        </div>
+    <main className="flex-1 min-w-0 flex flex-col items-center gap-4 pb-12">
+      {/* 動画スケルトン（メイン領域） */}
+      <div className="w-full px-4 sm:px-6 md:px-0 min-[1680px]:px-2 min-[1680px]:pt-8 pt-16 md:pt-8">
+        <Skeleton className="w-full aspect-video rounded-2xl" />
+      </div>
 
-        {/* Article body skeleton */}
-        <div className="space-y-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton
-              key={i}
-              className="h-4"
-              style={{ width: `${70 + Math.random() * 30}%` }}
-            />
-          ))}
+      {/* タイトル & 本文スケルトン */}
+      <div className="w-full px-4 sm:px-6 md:px-0 py-0 min-[1680px]:px-2">
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-8 w-3/4" />
+          <div className="space-y-3 pt-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton
+                key={i}
+                className="h-4"
+                style={{ width: `${70 + ((i * 13) % 30)}%` }}
+              />
+            ))}
+          </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -3,8 +3,7 @@ import { notFound } from "next/navigation";
 import { getArticleWithContext, getArticleMetadata, getAllArticles } from "@/lib/sanity";
 import { getSubscriptionStatus, canAccessContent } from "@/lib/subscription";
 import { isBookmarked } from "@/lib/services/bookmarks";
-import { getArticleProgress, getLessonProgress, getLessonStatus } from "@/lib/services/progress";
-import ArticleDetailClient from "./ArticleDetailClient";
+import { getArticleProgress } from "@/lib/services/progress";
 import { ViewHistoryRecorder } from "@/components/article/ViewHistoryRecorder";
 import VideoSection from "@/components/article/VideoSection";
 import HeadingSection from "@/components/article/HeadingSection";
@@ -66,6 +65,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 // ページコンポーネント（Server Component）
+// サイドナビは layout.tsx 側で描画される（記事間遷移時の保持のため）
 export default async function ArticlePage({ params }: PageProps) {
   const { slug } = await params;
   const [article, subscription] = await Promise.all([
@@ -77,28 +77,14 @@ export default async function ArticlePage({ params }: PageProps) {
     notFound();
   }
 
-  // lesson 全体の記事 ID 一覧を集める（楽観的 UI 用の初期値計算に使う）
-  const allLessonArticleIds: string[] = [];
-  if (article.lessonInfo?.quests) {
-    for (const quest of article.lessonInfo.quests) {
-      for (const art of quest.articles) {
-        allLessonArticleIds.push(art._id);
-      }
-    }
-  }
   const lessonId = article.lessonInfo?._id || "";
 
-  // ブックマーク・完了状態・レッスン進捗・lesson status を並列取得
-  const [bookmarked, progressStatus, lessonProgress, lessonStatus] = await Promise.all([
+  // ブックマーク・記事完了状態を並列取得（記事固有のデータのみ）
+  const [bookmarked, progressStatus] = await Promise.all([
     isBookmarked(article._id),
     getArticleProgress(article._id),
-    lessonId && allLessonArticleIds.length > 0
-      ? getLessonProgress(lessonId, allLessonArticleIds)
-      : Promise.resolve(null),
-    lessonId ? getLessonStatus(lessonId) : Promise.resolve("not_started" as const),
   ]);
   const isCompleted = progressStatus === "completed";
-  const initialCompletedArticleIds = lessonProgress?.completedArticleIds ?? [];
 
   // プレミアムコンテンツへのアクセス権限チェック
   const hasAccess = canAccessContent(article.isPremium || false, subscription.planType);
@@ -155,22 +141,18 @@ export default async function ArticlePage({ params }: PageProps) {
 
   return (
     <>
-    <script
-      {...jsonLdScriptProps(
-        generateArticleJsonLd({
-          title: article.title,
-          description: article.excerpt || `${article.title}の学習コンテンツ`,
-          url: `/articles/${slug}`,
-          publishedAt: article.publishedAt || new Date().toISOString(),
-          image: article.thumbnailUrl,
-        })
-      )}
-    />
-    <ArticleDetailClient
-      article={article}
-      initialCompletedArticleIds={initialCompletedArticleIds}
-      initialLessonStatus={lessonStatus}
-    >
+      <script
+        {...jsonLdScriptProps(
+          generateArticleJsonLd({
+            title: article.title,
+            description: article.excerpt || `${article.title}の学習コンテンツ`,
+            url: `/articles/${slug}`,
+            publishedAt: article.publishedAt || new Date().toISOString(),
+            image: article.thumbnailUrl,
+          })
+        )}
+      />
+
       {/* 閲覧履歴を記録（プレミアムでロックされていない場合のみ） */}
       {hasAccess && <ViewHistoryRecorder articleId={article._id} />}
 
@@ -247,7 +229,6 @@ export default async function ArticlePage({ params }: PageProps) {
           </div>
         </div>
       </main>
-    </ArticleDetailClient>
     </>
   );
 }

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@sanity/client";
 import imageUrlBuilder from "@sanity/image-url";
 import { unstable_cache } from "next/cache";
+import { cache } from "react";
 import type { LessonWithDetails, LessonMetadata, Lesson, ArticleWithContext, Feedback, FeedbackCategory } from "@/types/sanity";
 import type { SanityRoadmapListItem, SanityRoadmapDetail } from "@/types/sanity-roadmap";
 import type { Guide, GuideCategory } from "@/types/guide";
@@ -245,7 +246,7 @@ export const getAllLessonsWithArticleIds = unstable_cache(
  * 記事詳細を取得（SSR用）
  * Quest と Lesson のコンテキスト情報も含む
  */
-export const getArticleWithContext = unstable_cache(
+export const getArticleWithContext = cache(unstable_cache(
   async (slug: string): Promise<ArticleWithContext | null> => {
     const query = `
     *[_type == "article" && slug.current == $slug][0] {
@@ -329,7 +330,7 @@ export const getArticleWithContext = unstable_cache(
   },
   ["sanity:article:withContext"],
   { tags: ["article", "quest", "lesson"], revalidate: 3600 }
-);
+));
 
 /**
  * OGP用の記事メタデータを取得


### PR DESCRIPTION
## Summary

[BON-330](https://linear.app/bono/issue/BON-330) の対応。`/articles/[slug]` ページの読み込み体験を改善する。

### 解決した課題

イシューで挙げられていた以下を解決する：

1. **全画面リロード感の解消** — サイドナビの記事リンクをクリックすると全画面リロード相当の再描画が走り「別ページに飛んだ感じ」が出ていた → サイドナビは layout に移して右側だけ切り替わるように
2. **ナビ速度の改善** — レッスンスコープのデータ取得を layout でまとめ、`getArticleWithContext` を React `cache()` でリクエスト内デデュープ → 同レッスン内ナビは 0.45s 前後（初回 1.5s）まで短縮

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/app/articles/[slug]/layout.tsx` 🆕 | サイドナビ（`ArticleDetailClient` ラッパー）と lesson スコープのデータ取得（`getLessonProgress` / `getLessonStatus`）をここで実施。`lessonId` を `key` にして別レッスン遷移時のみ remount |
| `src/app/articles/[slug]/page.tsx` | `ArticleDetailClient` ラップを除去し、main コンテンツ（動画・タイトル・本文）と記事固有データ（subscription / bookmark / article progress）のみ担当 |
| `src/app/articles/[slug]/loading.tsx` | サイドナビ表示維持を前提に、main 領域のみのスケルトンに（`flex-1 min-w-0`） |
| `src/lib/sanity.ts` | `getArticleWithContext` に React `cache()` を被せて layout/page の重複フェッチを排除 |

## 期待される体験

- **同じレッスン内の記事間遷移** → サイドナビは固定表示・スクロール位置・開閉状態が保持されたまま、右側のメインだけ loading skeleton → 新コンテンツへ
- **別レッスンへ遷移** → サイドナビごと remount（key=lessonId が変わる）
- **初回ロード** → スケルトン対象が main 部分だけになり、サイドナビは先にレンダリングされるので体感が軽い

## 検証結果（ローカル `npm run dev`）

```
GET /articles/uiinfoartchitecture_uidesign_-lesson2     200 in 1564ms  (cold: compile + first render)
GET /articles/info_architecture_is_good-lesson2         200 in 1986ms  (different lesson, cold)
GET /articles/info_architecture_is_good_2-lesson2       200 in  467ms  (same lesson, cached)
GET /articles/info_architecture_is_good_3-lesson2       200 in  452ms  (same lesson, cached)
```

サイドナビ HTML を 2 記事間で diff した結果、12,753 バイト中の差分はアクティブハイライト位置のみ（構造は完全一致）。

- ✅ `npx tsc --noEmit` 通過
- ✅ `npm run build` 通過（`/articles/[slug]` は cookies を使うため元々動的レンダリング）

## 今後の段階的改善案（このPRには含めない）

ユーザーから「丁寧に1つずつ」進めたい要望があり、まずは中核となる「右側だけ切り替わる」体験を本PRで実現する。さらなる改善は効果検証後に検討：

- **動画 facade パターン**: 初期表示はサムネイル + 再生ボタン、クリックで Vimeo/YouTube player をマウント → 初期ロードから player.js を除外
- **`<Link prefetch={true}>` 明示** + サイドナビ hover prefetch 強化
- **Suspense でメイン段階表示**: Heading は即時、動画/本文は別 Suspense 境界で並列ストリーミング

## Test plan

- [ ] `/articles/[slug]` を開き、左サイドナビから同じレッスンの別記事をクリック → 全画面が真っ白にならず、右側だけ skeleton → 新コンテンツに切り替わる
- [ ] 上記の遷移で、サイドナビのスクロール位置・開閉状態（PCサイドバーの幅）が保持される
- [ ] 別レッスンの記事 (`/lessons` → 別レッスンの記事) を開いた時、サイドナビが正しく新レッスン用に切り替わる
- [ ] 記事完了ボタンを押すと、サイドナビのチェックマークが即座に反映される（既存の楽観的UIが壊れていない）
- [ ] モバイルでメニューボタン → サイドナビ表示 → 別記事タップで遷移が動作する
- [ ] プレミアム未契約での記事閲覧時、ロックUIが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)