### PR TITLE
feat: ガイドに「デザイン実践」カテゴリを追加

### DIFF
--- a/src/components/guide/GuideCategoryFilter.tsx
+++ b/src/components/guide/GuideCategoryFilter.tsx
@@ -3,13 +3,14 @@
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { GUIDE_CATEGORIES } from "@/lib/guideCategories";
-import { Briefcase, BookOpen, TrendingUp, Wrench } from "lucide-react";
+import { Briefcase, BookOpen, TrendingUp, Wrench, Compass } from "lucide-react";
 
 const categoryIcons: Record<string, typeof Briefcase> = {
   career: Briefcase,
   learning: BookOpen,
   industry: TrendingUp,
   tools: Wrench,
+  practice: Compass,
 };
 
 interface GuideCategoryFilterProps {

--- a/src/lib/guideCategories.ts
+++ b/src/lib/guideCategories.ts
@@ -29,10 +29,10 @@ export const GUIDE_CATEGORIES: GuideCategoryInfo[] = [
     icon: "wrench",
   },
   {
-    id: "design-knowledge",
-    label: "デザイン知識",
-    description: "配色・レイアウトなどデザインの基礎知識",
-    icon: "palette",
+    id: "practice",
+    label: "デザイン実践",
+    description: "デザインの基礎から現場ケース別の進め方まで、実際に手を動かすための知識",
+    icon: "compass",
   },
 ];
 

--- a/src/types/guide.ts
+++ b/src/types/guide.ts
@@ -3,7 +3,7 @@ import type { PortableTextBlock } from "@portabletext/types";
 /**
  * ガイドカテゴリの型定義
  */
-export type GuideCategory = "career" | "learning" | "industry" | "tools" | "design-knowledge";
+export type GuideCategory = "career" | "learning" | "industry" | "tools" | "practice";
 
 /**
  * ガイド記事の型定義（Sanity）


### PR DESCRIPTION
## Summary

- ガイドに新カテゴリ **「デザイン実践」(`practice`)** を追加
- 未稼働だった `design-knowledge` カテゴリを整理（型・定義リストから削除）
- フィルタアイコンに `Compass` (lucide-react) を採用

## なぜ

デザインを進める上での実践知（基礎〜現場ケース別の進め方）を扱うコンテンツが、既存4カテゴリ（career / learning / industry / tools）に収まりが悪かった。`design-knowledge` は型・定義リストに残っていたが Sanity スキーマに無く未稼働状態だったため、整理して `practice` に置き換える。

## 補足: 関連変更（このPRには含まれない）

- mainブランチ側 `sanity-studio/schemaTypes/guide.ts` にも `practice` カテゴリの追加が必要（別途対応）
- Sanity hosted Studio への `npx sanity deploy` 実行が必要（Studio UI でカテゴリ選択肢に出るようにする）

## Test plan

- [ ] `/guide` ページのカテゴリフィルタに「デザイン実践」タブが表示される
- [ ] 「デザイン実践」タブをクリックすると `practice` カテゴリの記事が表示される
- [ ] 既存の career/learning/industry/tools カテゴリが正常に動作する
- [ ] design-knowledge を参照しているコードが他に残っていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)