### PR TITLE
feat: 受講者ストーリー & アウトプット まわり (BON-327)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,14 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "cdn.prod.website-files.com",
       },
+      {
+        protocol: "https",
+        hostname: "placehold.co",
+      },
+      {
+        protocol: "https",
+        hostname: "api.dicebear.com",
+      },
     ],
   },
 };

--- a/scripts/delete-test-outputs.ts
+++ b/scripts/delete-test-outputs.ts
@@ -1,0 +1,40 @@
+/**
+ * テストデータの userOutput を削除する。
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+const IDS = [
+  "nVq92pLtGvqp6jQ0pdDgpp", // テスト
+  "osKfv7xko3C4F5yryC5Jg4", // あきら
+];
+
+async function main() {
+  for (const id of IDS) {
+    await client.delete(id);
+    console.log(`✅ 削除完了: ${id}`);
+  }
+
+  const remaining = await client.fetch(
+    `*[_type == "userOutput" && _id in $ids]{ _id }`,
+    { ids: IDS }
+  );
+  console.log(`\n削除後の残存件数: ${(remaining as unknown[])?.length ?? 0}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/find-test-outputs.ts
+++ b/scripts/find-test-outputs.ts
@@ -1,0 +1,57 @@
+/**
+ * テストデータと思われる userOutput を検索する。
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+async function main() {
+  const targets = ["テスト", "あきら"];
+
+  // 完全一致
+  const found = await client.fetch(
+    `*[_type == "userOutput" && (
+      author.displayName in $targets ||
+      author.slackAccountName in $targets ||
+      author.userId in $targets
+    )] {
+      _id, _type, articleTitle, articleUrl, author, submittedAt, _createdAt
+    } | order(_createdAt desc)`,
+    { targets }
+  );
+
+  console.log(`=== 完全一致で見つかった件数: ${(found as unknown[])?.length ?? 0} ===\n`);
+  console.log(JSON.stringify(found, null, 2));
+
+  // 念のため部分一致でも検索（テストXX、あきらXX 等）
+  const partial = await client.fetch(
+    `*[_type == "userOutput" && (
+      author.displayName match "テスト*" ||
+      author.displayName match "*テスト*" ||
+      author.displayName match "あきら*" ||
+      author.slackAccountName match "テスト*" ||
+      author.slackAccountName match "*テスト*" ||
+      author.slackAccountName match "あきら*"
+    )] {
+      _id, articleTitle, articleUrl, author, submittedAt
+    } | order(_createdAt desc)`
+  );
+  console.log(`\n=== 部分一致で見つかった件数: ${(partial as unknown[])?.length ?? 0} ===\n`);
+  console.log(JSON.stringify(partial, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/import-ai-ui-styling-lesson.ts
+++ b/scripts/import-ai-ui-styling-lesson.ts
@@ -1,0 +1,539 @@
+/**
+ * Sanity 本番に「AIxUIスタイリング入門」レッスンと、その配下の Quest/Article を
+ * 一括投入するスクリプト。
+ *
+ * 流れ:
+ *   1. ローカルの Markdown ファイルを Portable Text に変換
+ *   2. Article 7件を create
+ *   3. Quest 3件を create（articles 参照付き）
+ *   4. Lesson 1件を create（quests 参照付き、isHidden=true で投入）
+ *   5. Quest の lesson 参照を後から patch
+ *
+ * 実行:
+ *   npx tsx scripts/import-ai-ui-styling-lesson.ts --dry-run   # 投入せず JSON 出力のみ
+ *   npx tsx scripts/import-ai-ui-styling-lesson.ts             # 本番投入
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import crypto from "crypto";
+import fs from "fs";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const writeToken = process.env.SANITY_WRITE_TOKEN;
+if (!writeToken && !DRY_RUN) {
+  console.error("⚠️  SANITY_WRITE_TOKEN が必要です（.env.local を確認）");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: writeToken,
+  useCdn: false,
+});
+
+// ============================================
+// 入力データ定義
+// ============================================
+
+const DOC_ROOT =
+  "/Users/kaitakumi/Documents/01_BONO事業/01_Docs/rebono/02_Projects/03AIxAIでUIデザインする実践入門ガイド";
+const ISSUES_ROOT =
+  "/Users/kaitakumi/Documents/01_BONO事業/01_Docs/rebono/issues";
+
+interface ArticleDef {
+  key: string;
+  questKey: string;
+  articleNumber: number;
+  title: string;
+  slug: string;
+  articleType: "intro" | "explain" | "practice" | "challenge" | "demo";
+  excerpt: string;
+  videoUrl?: string;
+  filePath: string;
+  /**
+   * 本文として抽出する範囲を絞るための関数。
+   * 未指定なら frontmatter 除去後の全文を本文とする。
+   */
+  extractBody?: (raw: string) => string;
+  tags: string[];
+}
+
+const ARTICLES: ArticleDef[] = [
+  {
+    key: "q1a1",
+    questKey: "q1",
+    articleNumber: 1,
+    title: "AIにUIを作らせて分かった、これからUIデザインで習得するべきこと",
+    slug: "ai-ui-styling-why-intro",
+    articleType: "intro",
+    excerpt:
+      "AIでそれなりのUIが作れる今、スタイリングの勉強はもういらない? 答えはNO。出張申請のSaaS画面を5パターン作って見えた、AI時代に本当に学ぶべき2つのことを、実例とともに解説します。",
+    filePath: `${DOC_ROOT}/序章の文章でWHYこのコンテンツが必要かをとう.md`,
+    extractBody: (raw) => {
+      // 「---」より下、「👇本文」以降を本文とする
+      const afterFrontMatter = raw.split(/^---\s*$/m).slice(1).join("---");
+      const afterMarker = afterFrontMatter.split("👇本文").slice(-1)[0];
+      return afterMarker.trim();
+    },
+    tags: ["AI", "UIスタイリング", "ディレクション"],
+  },
+  {
+    key: "q2a1",
+    questKey: "q2",
+    articleNumber: 1,
+    title: "土台づくり｜環境構築・ハブページ・パターンA",
+    slug: "ai-ui-styling-foundation-pattern-a",
+    articleType: "practice",
+    excerpt:
+      "初学者がAIを使ってUIスタイリングを学ぶ実践シリーズ第1回。環境構築、パターン比較ページ、パターンA（指示なし）を実装し、AIが作ったスタイリングを後から分解して理解するための土台を作ります。",
+    videoUrl: "https://vimeo.com/1197228069",
+    filePath: `${DOC_ROOT}/動画詳細ページ記事/01_土台づくり_環境構築・ハブページ・パターンA.md`,
+    tags: ["AI", "UIスタイリング", "環境構築", "実践"],
+  },
+  {
+    key: "q2a2",
+    questKey: "q2",
+    articleNumber: 2,
+    title: "パターンBをつくる｜ディレクション次第でUIは変わる",
+    slug: "ai-ui-styling-pattern-b-direction",
+    articleType: "practice",
+    excerpt:
+      "AIを使ってUIスタイリングを学ぶ実践シリーズ。参考画像をコンポーネント・トークン・ページ全体の3層で分解させる指示を組み立て、パターンB（参考から学ぶver.）を実装。AIに頼って雰囲気を出すのではなく、UIの「普通」を分解して学ぶ土台をつくります。",
+    videoUrl: "https://vimeo.com/1197228011",
+    filePath: `${DOC_ROOT}/動画詳細ページ記事/02_パターンBをつくる_ディレクション次第でUIは変わる.md`,
+    tags: ["AI", "UIスタイリング", "ディレクション", "パターン比較"],
+  },
+  {
+    key: "q2a3",
+    questKey: "q2",
+    articleNumber: 3,
+    title: "スタイリング解説ページをつくる｜なぜこのUIになったかを言語化する",
+    slug: "ai-ui-styling-explanation-page",
+    articleType: "practice",
+    excerpt:
+      "AIを使ってUIスタイリングを学ぶ実践シリーズ。生成したパターンの「なぜこのUIになったか」をAIに言語化させて解説ページを作り、画像でビジュアライズまで仕上げます。AIの作業メモリが残っているうちに分解させることで、自分のデザインスキルに変換していくフェーズです。",
+    videoUrl: "https://vimeo.com/1197228107",
+    filePath: `${DOC_ROOT}/動画詳細ページ記事/03_スタイリング解説ページをつくる_なぜこのUIになったかを言語化する.md`,
+    tags: ["AI", "UIスタイリング", "解説", "分解"],
+  },
+  {
+    key: "q2a4",
+    questKey: "q2",
+    articleNumber: 4,
+    title: "design.md を解説する｜マークダウンだけではテイストは作りきれない",
+    slug: "ai-ui-styling-design-md",
+    articleType: "explain",
+    excerpt:
+      "AIを使ってUIスタイリングを学ぶ実践シリーズ。パターンDで使う `design.md`（デザインの振る舞いをマークダウンで定義するファイル）を解説します。Stitchなどで流行りつつある形式ですが、文字だけでテイストを作りきるのは難しい前提で、トークンや画像とどう組むかを考えます。",
+    videoUrl: "https://vimeo.com/1197228143",
+    filePath: `${DOC_ROOT}/動画詳細ページ記事/04_designmdを解説する_マークダウンだけではテイストは作りきれない.md`,
+    tags: ["AI", "design.md", "スタイリング"],
+  },
+  {
+    key: "q2a5",
+    questKey: "q2",
+    articleNumber: 5,
+    title:
+      "全パターンを比較する｜「作れた」で終わらずコントロールできるまで持っていく",
+    slug: "ai-ui-styling-pattern-comparison",
+    articleType: "practice",
+    excerpt:
+      "AIを使ってUIスタイリングを学ぶ実践シリーズ。指示なしAから design.md を使ったパターンまで、生成した全パターンを並べて比較します。AIで「今っぽいUIが作れた」で終わらせず、調整・コントロールできるところまで持っていくために、トークンとコンポーネントの分解が肝になる回です。",
+    videoUrl: "https://vimeo.com/1197228177",
+    filePath: `${DOC_ROOT}/動画詳細ページ記事/05_全パターンを比較する_「作れた」で終わらずコントロールできるまで持っていく.md`,
+    tags: ["AI", "UIスタイリング", "パターン比較", "コントロール"],
+  },
+  {
+    key: "q3a1",
+    questKey: "q3",
+    articleNumber: 1,
+    title: "作成中",
+    slug: "ai-ui-styling-coming-soon",
+    articleType: "intro",
+    excerpt: "このレッスンの続きを準備中です。",
+    filePath: `${ISSUES_ROOT}/作成中.....md`,
+    tags: ["AI", "UIスタイリング"],
+  },
+];
+
+interface QuestDef {
+  key: string;
+  questNumber: number;
+  title: string;
+  slug: string;
+  goal: string;
+  description?: string;
+}
+
+const QUESTS: QuestDef[] = [
+  {
+    key: "q1",
+    questNumber: 1,
+    title: "クエスト1: AIでUI作成して、デザインスキルは上がるの？",
+    slug: "ai-ui-styling-q1-why",
+    goal: "AIでUIを作る前に、なぜスタイリングのディレクションスキルが必要なのかを理解する",
+  },
+  {
+    key: "q2",
+    questNumber: 2,
+    title: "クエスト2: AIにUIスタイリングを生成させる",
+    slug: "ai-ui-styling-q2-generate",
+    goal: "テイスト→ルール→トークン→部品→画面 の構造でAIに指示し、狙ったスタイリングを生成・分解できる状態にする",
+  },
+  {
+    key: "q3",
+    questNumber: 3,
+    title: "クエスト3: スタイリングシステムをつくり、まなぶ",
+    slug: "ai-ui-styling-q3-system",
+    goal: "（準備中）",
+  },
+];
+
+const LESSON_DEF = {
+  title: "AIxUIスタイリング入門",
+  slug: "ai-ui-styling-intro",
+  description:
+    "AIでUIの見た目が作れたらそれでおしまいなのか？デザイン力が絡むと変わる出力の差を理解した後に\"UIスタイルのディレクション\"に必要なデザインシステムを習得する入門コンテンツです。",
+  isPremium: false,
+  isHidden: true, // 安全のため一旦非公開で投入、Studio 確認後に公開に切り替え
+  tags: ["AI", "UIスタイリング", "デザインシステム"],
+  purposes: [
+    "AIにUIスタイリングをディレクションする力を身につける",
+    "テイスト→ルール→トークン→部品→画面 という構造を理解する",
+    "デザインシステムの基本を入門レベルで習得する",
+  ],
+};
+
+// ============================================
+// Portable Text 変換
+// ============================================
+
+function randKey(len = 12): string {
+  return crypto.randomBytes(len / 2).toString("hex");
+}
+
+type PtSpan = {
+  _type: "span";
+  _key: string;
+  marks: string[];
+  text: string;
+};
+
+type PtMarkDef = { _key: string; _type: string; href?: string };
+
+type PtBlock = {
+  _type: "block";
+  _key: string;
+  style: string;
+  markDefs: PtMarkDef[];
+  children: PtSpan[];
+  level?: number;
+  listItem?: string;
+};
+
+/**
+ * Markdown ファイルから frontmatter とコメントを除去
+ */
+function stripMeta(raw: string): string {
+  let out = raw;
+  // YAML frontmatter (---\n...---\n) を除去
+  out = out.replace(/^---\n[\s\S]*?\n---\n?/, "");
+  // HTML コメント
+  out = out.replace(/<!--[\s\S]*?-->/g, "");
+  return out.trim();
+}
+
+/**
+ * 1行の Markdown 文字列をインラインで解析し、span 配列と markDefs を返す
+ */
+function parseInline(text: string): { spans: PtSpan[]; markDefs: PtMarkDef[] } {
+  const markDefs: PtMarkDef[] = [];
+  const tokens: Array<{ marks: string[]; text: string }> = [];
+
+  // 順序: link → bold の順で処理（リンクテキストが太字を含む可能性は今回想定しない）
+  // 正規表現でトークン化する: ** ** と [text](url) を抜き出す
+  const pattern = /(\[([^\]]+)\]\(([^)]+)\))|(\*\*([^*]+)\*\*)/g;
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+
+  while ((m = pattern.exec(text)) !== null) {
+    if (m.index > lastIndex) {
+      tokens.push({ marks: [], text: text.slice(lastIndex, m.index) });
+    }
+    if (m[1]) {
+      // リンク [text](url)
+      const linkKey = randKey();
+      markDefs.push({ _key: linkKey, _type: "link", href: m[3] });
+      tokens.push({ marks: [linkKey], text: m[2] });
+    } else if (m[4]) {
+      // 太字 **text**
+      tokens.push({ marks: ["strong"], text: m[5] });
+    }
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < text.length) {
+    tokens.push({ marks: [], text: text.slice(lastIndex) });
+  }
+  if (tokens.length === 0) {
+    tokens.push({ marks: [], text });
+  }
+
+  const spans: PtSpan[] = tokens
+    .filter((t) => t.text.length > 0)
+    .map((t) => ({
+      _type: "span",
+      _key: randKey(),
+      marks: t.marks,
+      text: t.text,
+    }));
+
+  return { spans, markDefs };
+}
+
+function buildBlock(
+  text: string,
+  style: string,
+  opts: { level?: number; listItem?: string } = {}
+): PtBlock {
+  const { spans, markDefs } = parseInline(text);
+  const block: PtBlock = {
+    _type: "block",
+    _key: randKey(),
+    style,
+    markDefs,
+    children: spans,
+  };
+  if (opts.level) block.level = opts.level;
+  if (opts.listItem) block.listItem = opts.listItem;
+  return block;
+}
+
+/**
+ * Markdown を Portable Text ブロック配列に変換
+ */
+function markdownToPortableText(md: string): PtBlock[] {
+  const lines = stripMeta(md).split("\n");
+  const blocks: PtBlock[] = [];
+  let paragraph: string[] = [];
+
+  const flush = () => {
+    if (paragraph.length === 0) return;
+    const text = paragraph.join(" ").trim();
+    if (text) blocks.push(buildBlock(text, "normal"));
+    paragraph = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\s+$/, ""); // 末尾の空白除去
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      flush();
+      continue;
+    }
+
+    // ヘッダー
+    const h = trimmed.match(/^(#{1,6})\s+(.+)$/);
+    if (h) {
+      flush();
+      const level = Math.min(h[1].length, 4);
+      blocks.push(buildBlock(h[2], `h${level}`));
+      continue;
+    }
+
+    // 引用
+    const q = trimmed.match(/^>\s?(.*)$/);
+    if (q) {
+      flush();
+      blocks.push(buildBlock(q[1], "blockquote"));
+      continue;
+    }
+
+    // 箇条書き（- or *）
+    const ul = trimmed.match(/^[-*]\s+(.+)$/);
+    if (ul) {
+      flush();
+      blocks.push(buildBlock(ul[1], "normal", { level: 1, listItem: "bullet" }));
+      continue;
+    }
+
+    // 番号付きリスト
+    const ol = trimmed.match(/^\d+\.\s+(.+)$/);
+    if (ol) {
+      flush();
+      blocks.push(buildBlock(ol[1], "normal", { level: 1, listItem: "number" }));
+      continue;
+    }
+
+    paragraph.push(trimmed);
+  }
+  flush();
+
+  return blocks;
+}
+
+// ============================================
+// メイン処理
+// ============================================
+
+async function main() {
+  console.log(`\n${DRY_RUN ? "🧪 DRY RUN" : "🚀 PRODUCTION"} モードで実行\n`);
+
+  // ---- 既存 slug の重複チェック ----
+  const allNewSlugs = [
+    LESSON_DEF.slug,
+    ...QUESTS.map((q) => q.slug),
+    ...ARTICLES.map((a) => a.slug),
+  ];
+  const existingSlugs = await client.fetch<
+    Array<{ _type: string; slug: { current: string } }>
+  >(
+    `*[_type in ["lesson", "quest", "article"] && slug.current in $slugs]{ _type, slug }`,
+    { slugs: allNewSlugs }
+  );
+  if (existingSlugs.length > 0) {
+    console.error("\n⛔ slug の重複があります。中止します:");
+    console.error(existingSlugs);
+    process.exit(1);
+  }
+  console.log("✅ slug 重複なし\n");
+
+  // ---- Article を 7件作成 ----
+  console.log("=== Articles 作成 ===");
+  const articleIds: Record<string, string> = {};
+  for (const def of ARTICLES) {
+    const raw = fs.readFileSync(def.filePath, "utf8");
+    const bodySource = def.extractBody ? def.extractBody(raw) : raw;
+    const content = markdownToPortableText(bodySource);
+
+    const doc: Record<string, unknown> = {
+      _type: "article",
+      title: def.title,
+      slug: { _type: "slug", current: def.slug },
+      articleNumber: def.articleNumber,
+      articleType: def.articleType,
+      excerpt: def.excerpt,
+      content,
+      tags: def.tags,
+      isPremium: false,
+      publishedAt: new Date().toISOString(),
+    };
+    if (def.videoUrl) doc.videoUrl = def.videoUrl;
+
+    if (DRY_RUN) {
+      console.log(`  📝 [${def.key}] ${def.title}`);
+      console.log(
+        `     slug=${def.slug}, articleType=${def.articleType}, blocks=${content.length}`
+      );
+      articleIds[def.key] = `dry-${def.key}`;
+    } else {
+      const created = await client.create(doc as { _type: string } & Record<string, unknown>);
+      articleIds[def.key] = created._id;
+      console.log(`  ✅ [${def.key}] _id=${created._id}  ${def.title}`);
+    }
+  }
+
+  // ---- Quest を 3件作成（articles 参照付き）----
+  console.log("\n=== Quests 作成 ===");
+  const questIds: Record<string, string> = {};
+  for (const def of QUESTS) {
+    const articleRefs = ARTICLES.filter((a) => a.questKey === def.key)
+      .sort((a, b) => a.articleNumber - b.articleNumber)
+      .map((a) => ({
+        _key: randKey(),
+        _type: "reference",
+        _ref: articleIds[a.key],
+      }));
+
+    const doc: Record<string, unknown> = {
+      _type: "quest",
+      title: def.title,
+      slug: { _type: "slug", current: def.slug },
+      questNumber: def.questNumber,
+      goal: def.goal,
+      articles: articleRefs,
+    };
+
+    if (DRY_RUN) {
+      console.log(`  📝 [${def.key}] ${def.title}`);
+      console.log(`     slug=${def.slug}, articles=${articleRefs.length}`);
+      questIds[def.key] = `dry-${def.key}`;
+    } else {
+      const created = await client.create(doc as { _type: string } & Record<string, unknown>);
+      questIds[def.key] = created._id;
+      console.log(`  ✅ [${def.key}] _id=${created._id}  ${def.title}`);
+    }
+  }
+
+  // ---- Lesson を作成（quests 参照付き）----
+  console.log("\n=== Lesson 作成 ===");
+  const questRefs = QUESTS.map((q) => ({
+    _key: randKey(),
+    _type: "reference",
+    _ref: questIds[q.key],
+  }));
+
+  const lessonDoc: Record<string, unknown> = {
+    _type: "lesson",
+    title: LESSON_DEF.title,
+    slug: { _type: "slug", current: LESSON_DEF.slug },
+    description: LESSON_DEF.description,
+    isPremium: LESSON_DEF.isPremium,
+    isHidden: LESSON_DEF.isHidden,
+    tags: LESSON_DEF.tags,
+    purposes: LESSON_DEF.purposes,
+    quests: questRefs,
+  };
+
+  let lessonId = "dry-lesson";
+  if (DRY_RUN) {
+    console.log(`  📝 ${LESSON_DEF.title}`);
+    console.log(
+      `     slug=${LESSON_DEF.slug}, isHidden=${LESSON_DEF.isHidden}, quests=${questRefs.length}`
+    );
+    console.log("\n--- Lesson doc (full) ---");
+    console.log(JSON.stringify(lessonDoc, null, 2));
+  } else {
+    const created = await client.create(lessonDoc);
+    lessonId = created._id;
+    console.log(`  ✅ _id=${created._id}  ${LESSON_DEF.title}`);
+  }
+
+  // ---- Quest の lesson 参照を patch ----
+  console.log("\n=== Quest に lesson 参照を patch ===");
+  for (const def of QUESTS) {
+    if (DRY_RUN) {
+      console.log(`  📝 [${def.key}] lesson 参照を ${lessonId} に設定（patch）`);
+    } else {
+      await client
+        .patch(questIds[def.key])
+        .set({ lesson: { _type: "reference", _ref: lessonId } })
+        .commit();
+      console.log(`  ✅ [${def.key}] lesson 参照付与`);
+    }
+  }
+
+  // ---- まとめ出力 ----
+  console.log("\n=== 完了 ===");
+  console.log("Lesson:", lessonId);
+  console.log("Quests:", JSON.stringify(questIds, null, 2));
+  console.log("Articles:", JSON.stringify(articleIds, null, 2));
+
+  if (DRY_RUN) {
+    console.log("\nℹ️  DRY RUN なので Sanity には何も書き込まれていません。");
+  } else {
+    console.log("\n✨ 本番投入完了");
+  }
+}
+
+main().catch((e) => {
+  console.error("\n💥 エラー:", e);
+  process.exit(1);
+});

--- a/scripts/import-stories.ts
+++ b/scripts/import-stories.ts
@@ -1,0 +1,287 @@
+/**
+ * lesson "dezainanokiyaria" 配下の article を Story にインポートする。
+ *
+ * 流れ:
+ *   1. 対象 23 件を取得
+ *   2. 各記事の Webflow URL から publishedAt を curl で取得
+ *   3. タイトル＋slug から person.name を抽出
+ *   4. Sanity に story document を作成（既存なら更新）
+ *
+ * 実行: npx tsx scripts/import-stories.ts [--dry-run]
+ *
+ * Sanity への書き込みには SANITY_WRITE_TOKEN が必要。
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const LESSON_SLUG = "dezainanokiyaria";
+const WEBFLOW_BASE = "https://www.bo-no.design/contents";
+const WEBFLOW_COLLECTION_ID = "6029d027f6cb8852cbce8c75";
+const WEBFLOW_TOKEN = process.env.WEBFLOW_TOKEN ||
+  "674b54cf2429858c005eb647787f444c749bb324a1ca1615b6cf4967b4033e76";
+
+const EXCLUDE_TITLE_PATTERNS = [
+  "未経験からフリーランスUIデザイナーになるステップ",
+  "Webデザインの価値を上げる方法",
+  "ビジュアルが良くても採用が通過されない理由",
+  "デザインで仕事を得られるスキル基準",
+  "資産化",
+  "デザイナーの相場",
+  "デザイナーが自分に合う会社を見分ける方法",
+  "ファーストキャリアはデザイン組織化された会社",
+  "ほぼラジオ",
+];
+
+const writeToken = process.env.SANITY_WRITE_TOKEN;
+if (!writeToken && !DRY_RUN) {
+  console.error("⚠️  SANITY_WRITE_TOKEN が必要です（.env.local を確認）");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: writeToken,
+  useCdn: false,
+});
+
+interface ArticleSource {
+  _id: string;
+  title: string;
+  slug: string;
+  publishedAt: string | null;
+  _createdAt: string;
+  excerpt?: string;
+  tags?: string[];
+  author?: string;
+  thumbnail?: { asset?: { _ref?: string } };
+  thumbnailUrl?: string;
+  content?: unknown[]; // PortableText
+}
+
+/**
+ * Webflow CMS API から全アイテムを取得し slug → lastPublished のマップを返す
+ */
+async function fetchWebflowPublishedMap(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  let offset = 0;
+  const limit = 100;
+
+  while (true) {
+    const res = await fetch(
+      `https://api.webflow.com/v2/collections/${WEBFLOW_COLLECTION_ID}/items?limit=${limit}&offset=${offset}`,
+      { headers: { Authorization: `Bearer ${WEBFLOW_TOKEN}` } }
+    );
+    if (!res.ok) {
+      console.error(`Webflow API error: ${res.status}`);
+      break;
+    }
+    const data: {
+      items: Array<{ lastPublished?: string | null; createdOn?: string; fieldData?: { slug?: string } }>;
+      pagination?: { total?: number };
+    } = await res.json();
+
+    for (const item of data.items) {
+      const slug = item.fieldData?.slug;
+      if (!slug) continue;
+      const publishedAt = item.lastPublished || item.createdOn;
+      if (publishedAt) map.set(slug, publishedAt);
+    }
+
+    offset += limit;
+    if (offset >= (data.pagination?.total ?? 0)) break;
+    // レート制限対策で少し待つ
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  console.log(`Webflow から ${map.size} 件の slug→publishedAt マップ取得\n`);
+  return map;
+}
+
+/**
+ * 外部URLから画像をダウンロードして Sanity にアップロード
+ * 返り値は image type のオブジェクト
+ */
+async function uploadImageFromUrl(
+  url: string
+): Promise<{ _type: "image"; asset: { _type: "reference"; _ref: string } } | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const ext = url.split(".").pop()?.split("?")[0]?.toLowerCase() || "jpg";
+    const asset = await client.assets.upload("image", buffer, {
+      filename: `story-hero.${ext}`,
+    });
+    return {
+      _type: "image",
+      asset: { _type: "reference", _ref: asset._id },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * タイトル+slug から person.name を抽出
+ * 優先順:
+ *   1. タイトル中の「〇〇さん」「〇〇くん」
+ *   2. slug の末尾（youhadouyate...{name}({数字|-copy})?）
+ *   3. フォールバック「BONO受講者」
+ */
+function extractPersonName(title: string, slug: string): string {
+  // 1. タイトルから「〜さん」「〜くん」
+  //    （日本語名・カタカナ・ローマ字に対応）
+  const honorificMatch = title.match(/([ぁ-んァ-ヶー一-龯a-zA-Z0-9]+?)(さん|くん)/);
+  if (honorificMatch) return `${honorificMatch[1]}${honorificMatch[2]}`;
+
+  // 2. slug の末尾
+  //    例: youhadouyatedezainani-nakano → nakano
+  //    例: youhadouyatedezainanihanzo-copy → hanzo
+  //    例: youhadouyatedesigner-rinneru01 → rinneru
+  //    例: youhadouyatedesigner-yanashi-01 → yanashi
+  //    例: youhadouyatedezainanimegu → megu
+  //    例: howareyoubecomethedesigner-genta → genta
+  const slugClean = slug
+    .replace(/-?(copy|0?\d+)$/i, "")
+    .replace(
+      /^(youhadouyatedezainani|youhadouyatedesigner|howareyoubecomethedesigner|howtobedesigner)/i,
+      ""
+    );
+  const slugMatch = slugClean.match(/-?([a-z]+)$/i);
+  if (slugMatch && slugMatch[1].length >= 2) {
+    const name = slugMatch[1];
+    return name.charAt(0).toUpperCase() + name.slice(1) + "さん";
+  }
+
+  return "BONO受講者";
+}
+
+/**
+ * title からカテゴリラベル相当のタグを推定（軸1: 経験背景）
+ * 「未経験」を含むなら「未経験」、それ以外は「業界経験あり」をデフォルト
+ */
+function guessTag(title: string): string {
+  if (title.includes("未経験")) return "未経験";
+  return "業界経験あり";
+}
+
+async function main() {
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE (Sanity に書き込みます)"}\n`);
+
+  // 1. 対象記事取得
+  const articles: ArticleSource[] = await client.fetch(
+    `
+    *[_type == "article" && quest->lesson->slug.current == $lessonSlug]
+    | order(_createdAt asc) {
+      _id,
+      title,
+      "slug": slug.current,
+      publishedAt,
+      _createdAt,
+      excerpt,
+      tags,
+      author,
+      thumbnail,
+      thumbnailUrl,
+      content
+    }
+  `,
+    { lessonSlug: LESSON_SLUG }
+  );
+
+  const included = articles.filter(
+    (a) => !EXCLUDE_TITLE_PATTERNS.some((p) => a.title.includes(p))
+  );
+
+  console.log(`対象 ${included.length}件 / 全 ${articles.length}件\n`);
+
+  // Webflow から公開日マップ取得
+  const webflowMap = await fetchWebflowPublishedMap();
+
+  let success = 0;
+  let failed = 0;
+
+  for (const [i, a] of included.entries()) {
+    const idx = `[${i + 1}/${included.length}]`;
+
+    // 公開日取得（Webflow → _createdAt）
+    const publishedAt = webflowMap.get(a.slug) || a._createdAt;
+
+    // 人名抽出
+    const personName = extractPersonName(a.title, a.slug);
+
+    // タグ
+    const tag = guessTag(a.title);
+
+    // excerpt（160字制限）
+    const excerpt = (a.excerpt || a.title).slice(0, 160);
+
+    // heroImage:
+    //   - article.thumbnail.asset._ref があればそれを使う（Sanity 内画像）
+    //   - なければ thumbnailUrl から画像をダウンロード → Sanity にアップロード
+    let heroImage:
+      | { _type: "image"; asset: { _type: "reference"; _ref: string } }
+      | null = null;
+
+    if (a.thumbnail?.asset?._ref) {
+      heroImage = {
+        _type: "image",
+        asset: { _type: "reference", _ref: a.thumbnail.asset._ref },
+      };
+    } else if (a.thumbnailUrl && !DRY_RUN) {
+      heroImage = await uploadImageFromUrl(a.thumbnailUrl);
+    }
+
+    const storyDoc = {
+      _id: `story-${a.slug}`,
+      _type: "story",
+      title: a.title,
+      slug: { _type: "slug", current: a.slug },
+      publishedAt,
+      excerpt,
+      heroImage,
+      person: {
+        name: personName,
+      },
+      category: "uiux_career_change",
+      tags: [tag],
+      body: a.content || [],
+    };
+
+    console.log(`${idx} ${a.title.slice(0, 50)}...`);
+    console.log(`     slug: ${a.slug}`);
+    console.log(`     publishedAt: ${publishedAt.slice(0, 10)} (${a.slug})`);
+    console.log(`     person: ${personName}, tag: #${tag}`);
+    console.log(`     heroImage: ${heroImage ? "✓ Sanity asset" : DRY_RUN ? "(dry-run: thumbnailUrl=" + (a.thumbnailUrl ? "あり→アップロード予定" : "なし") + ")" : "✗ アップロード失敗"}`);
+
+    if (DRY_RUN) {
+      console.log("     ⏭ DRY RUN: スキップ\n");
+      continue;
+    }
+
+    try {
+      // createOrReplace で上書きインポート
+      await client.createOrReplace(storyDoc);
+      console.log(`     ✅ インポート成功\n`);
+      success++;
+    } catch (err) {
+      console.error(`     ❌ 失敗: ${err}\n`);
+      failed++;
+    }
+  }
+
+  console.log(`\n=== 完了 ===`);
+  console.log(`成功: ${success} / 失敗: ${failed} / 全 ${included.length}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/inspect-articles.ts
+++ b/scripts/inspect-articles.ts
@@ -1,0 +1,102 @@
+/**
+ * lesson "dezainanokiyaria" 配下の article を取得し、
+ * 除外リストを適用してインポート候補をリストアップ。
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  useCdn: false,
+});
+
+const LESSON_SLUG = "dezainanokiyaria";
+
+// BON-327 コメント c9a6bd84 で指定された除外記事（タイトル部分マッチ）
+// + ユーザー追加除外（ラジオ3本・一般ハウツー1本）
+const EXCLUDE_TITLE_PATTERNS = [
+  "未経験からフリーランスUIデザイナーになるステップ",
+  "Webデザインの価値を上げる方法",
+  "ビジュアルが良くても採用が通過されない理由",
+  "デザインで仕事を得られるスキル基準",
+  "資産化",
+  "デザイナーの相場",
+  "デザイナーが自分に合う会社を見分ける方法",
+  "ファーストキャリアはデザイン組織化された会社",
+  // 追加除外（インタビューではない・ラジオ系）
+  "ほぼラジオ",
+];
+
+async function main() {
+  // lesson 配下の quest を経由して article を取得
+  const articles = await client.fetch(
+    `
+    *[_type == "article" && quest->lesson->slug.current == $lessonSlug]
+    | order(publishedAt desc, _createdAt desc) {
+      _id,
+      title,
+      "slug": slug.current,
+      publishedAt,
+      _createdAt,
+      excerpt,
+      tags,
+      author,
+      isPremium,
+      "thumbnailUrl": thumbnail.asset->url,
+      thumbnailUrl,
+      "questTitle": quest->title,
+      "lessonTitle": quest->lesson->title
+    }
+  `,
+    { lessonSlug: LESSON_SLUG }
+  );
+
+  console.log(`=== lesson "${LESSON_SLUG}" 配下の article ===`);
+  console.log("総件数:", articles.length);
+  console.log("");
+
+  // 除外チェック
+  const included: typeof articles = [];
+  const excluded: { title: string; reason: string }[] = [];
+
+  for (const a of articles) {
+    const excludePattern = EXCLUDE_TITLE_PATTERNS.find((p) => a.title.includes(p));
+    if (excludePattern) {
+      excluded.push({ title: a.title, reason: excludePattern });
+    } else {
+      included.push(a);
+    }
+  }
+
+  console.log(`--- インポート対象 (${included.length}件) ---`);
+  for (const a of included) {
+    const date = a.publishedAt ? a.publishedAt.slice(0, 10) : a._createdAt?.slice(0, 10) ?? "?";
+    const hasThumb = a.thumbnailUrl ? "🖼" : "❌";
+    console.log(`${hasThumb} [${date}] ${a.title}`);
+    console.log(`   slug: ${a.slug}`);
+  }
+
+  console.log(`\n--- 除外 (${excluded.length}件) ---`);
+  for (const e of excluded) {
+    console.log(`× ${e.title}`);
+    console.log(`   reason: matched "${e.reason}"`);
+  }
+
+  // サマリー
+  const withThumb = included.filter((a) => a.thumbnailUrl).length;
+  const withPublished = included.filter((a) => a.publishedAt).length;
+  console.log(`\n=== サマリー ===`);
+  console.log(`総件数: ${articles.length}`);
+  console.log(`インポート対象: ${included.length}`);
+  console.log(`  └ thumbnail あり: ${withThumb}`);
+  console.log(`  └ publishedAt あり: ${withPublished}`);
+  console.log(`除外: ${excluded.length}`);
+}
+
+main().catch(console.error);

--- a/scripts/inspect-lesson-schema.ts
+++ b/scripts/inspect-lesson-schema.ts
@@ -1,0 +1,81 @@
+/**
+ * 既存 Sanity Lesson/Quest/Article の構造を確認するための調査スクリプト。
+ *
+ * 実行: npx tsx scripts/inspect-lesson-schema.ts
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+async function main() {
+  // 1) lessonNumber 一覧と最大値
+  const lessonNumbers = await client.fetch<Array<{ _id: string; title: string; lessonNumber: number | null; slug: { current: string } }>>(
+    `*[_type == "lesson"] | order(lessonNumber asc){ _id, title, lessonNumber, slug }`
+  );
+  console.log("=== すべての Lesson (lessonNumber 昇順) ===");
+  for (const l of lessonNumbers) {
+    console.log(`#${l.lessonNumber ?? "(null)"}  ${l.title}  → slug: ${l.slug?.current}`);
+  }
+  const maxNumber = lessonNumbers
+    .map((l) => l.lessonNumber ?? 0)
+    .reduce((m, n) => (n > m ? n : m), 0);
+  console.log(`\nmax lessonNumber: ${maxNumber}\n`);
+
+  // 2) サンプル Lesson の全フィールド（最新作成）
+  const sampleLesson = await client.fetch(
+    `*[_type == "lesson"] | order(_createdAt desc)[0]{ ... }`
+  );
+  console.log("=== サンプル Lesson (最新作成) の全フィールド ===");
+  console.log(JSON.stringify(sampleLesson, null, 2));
+
+  // 3) サンプル Quest
+  const sampleQuest = await client.fetch(
+    `*[_type == "quest"] | order(_createdAt desc)[0]{ ... }`
+  );
+  console.log("\n=== サンプル Quest の全フィールド ===");
+  console.log(JSON.stringify(sampleQuest, null, 2));
+
+  // 4) サンプル Article（最新）
+  const sampleArticle = await client.fetch(
+    `*[_type == "article"] | order(_createdAt desc)[0]{ ... }`
+  );
+  console.log("\n=== サンプル Article の全フィールド ===");
+  console.log(JSON.stringify(sampleArticle, null, 2));
+
+  // 5) articleType の取りうる値
+  const articleTypes = await client.fetch<string[]>(
+    `array::unique(*[_type == "article" && defined(articleType)].articleType)`
+  );
+  console.log("\n=== 使われている articleType 一覧 ===");
+  console.log(articleTypes);
+
+  // 6) tags のサンプル
+  const tags = await client.fetch<string[]>(
+    `array::unique(*[_type == "lesson" && defined(tags)].tags[])`
+  );
+  console.log("\n=== Lesson tags サンプル ===");
+  console.log(tags?.slice(0, 30));
+
+  // 7) category の選択肢
+  const categories = await client.fetch(
+    `*[_type == "lessonCategory"]{ _id, title, slug }`
+  );
+  console.log("\n=== lessonCategory 一覧 ===");
+  console.log(JSON.stringify(categories, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/inspect-pt-sample.ts
+++ b/scripts/inspect-pt-sample.ts
@@ -1,0 +1,132 @@
+/**
+ * import-ai-ui-styling-lesson.ts と同じ変換ロジックを呼び出して
+ * 1 記事の Portable Text を標準出力する確認用スクリプト。
+ */
+
+import fs from "fs";
+import crypto from "crypto";
+
+const FILE = process.argv[2];
+if (!FILE) {
+  console.error("Usage: npx tsx scripts/inspect-pt-sample.ts <markdown-file>");
+  process.exit(1);
+}
+
+function randKey(len = 12): string {
+  return crypto.randomBytes(len / 2).toString("hex");
+}
+
+type PtSpan = { _type: "span"; _key: string; marks: string[]; text: string };
+type PtMarkDef = { _key: string; _type: string; href?: string };
+type PtBlock = {
+  _type: "block";
+  _key: string;
+  style: string;
+  markDefs: PtMarkDef[];
+  children: PtSpan[];
+  level?: number;
+  listItem?: string;
+};
+
+function stripMeta(raw: string): string {
+  let out = raw;
+  out = out.replace(/^---\n[\s\S]*?\n---\n?/, "");
+  out = out.replace(/<!--[\s\S]*?-->/g, "");
+  return out.trim();
+}
+
+function parseInline(text: string): { spans: PtSpan[]; markDefs: PtMarkDef[] } {
+  const markDefs: PtMarkDef[] = [];
+  const tokens: Array<{ marks: string[]; text: string }> = [];
+  const pattern = /(\[([^\]]+)\]\(([^)]+)\))|(\*\*([^*]+)\*\*)/g;
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(text)) !== null) {
+    if (m.index > lastIndex)
+      tokens.push({ marks: [], text: text.slice(lastIndex, m.index) });
+    if (m[1]) {
+      const linkKey = randKey();
+      markDefs.push({ _key: linkKey, _type: "link", href: m[3] });
+      tokens.push({ marks: [linkKey], text: m[2] });
+    } else if (m[4]) {
+      tokens.push({ marks: ["strong"], text: m[5] });
+    }
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < text.length) tokens.push({ marks: [], text: text.slice(lastIndex) });
+  if (tokens.length === 0) tokens.push({ marks: [], text });
+  const spans: PtSpan[] = tokens
+    .filter((t) => t.text.length > 0)
+    .map((t) => ({ _type: "span", _key: randKey(), marks: t.marks, text: t.text }));
+  return { spans, markDefs };
+}
+
+function buildBlock(
+  text: string,
+  style: string,
+  opts: { level?: number; listItem?: string } = {}
+): PtBlock {
+  const { spans, markDefs } = parseInline(text);
+  const block: PtBlock = {
+    _type: "block",
+    _key: randKey(),
+    style,
+    markDefs,
+    children: spans,
+  };
+  if (opts.level) block.level = opts.level;
+  if (opts.listItem) block.listItem = opts.listItem;
+  return block;
+}
+
+function markdownToPortableText(md: string): PtBlock[] {
+  const lines = stripMeta(md).split("\n");
+  const blocks: PtBlock[] = [];
+  let paragraph: string[] = [];
+  const flush = () => {
+    if (paragraph.length === 0) return;
+    const text = paragraph.join(" ").trim();
+    if (text) blocks.push(buildBlock(text, "normal"));
+    paragraph = [];
+  };
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\s+$/, "");
+    const trimmed = line.trim();
+    if (!trimmed) {
+      flush();
+      continue;
+    }
+    const h = trimmed.match(/^(#{1,6})\s+(.+)$/);
+    if (h) {
+      flush();
+      blocks.push(buildBlock(h[2], `h${Math.min(h[1].length, 4)}`));
+      continue;
+    }
+    const q = trimmed.match(/^>\s?(.*)$/);
+    if (q) {
+      flush();
+      blocks.push(buildBlock(q[1], "blockquote"));
+      continue;
+    }
+    const ul = trimmed.match(/^[-*]\s+(.+)$/);
+    if (ul) {
+      flush();
+      blocks.push(buildBlock(ul[1], "normal", { level: 1, listItem: "bullet" }));
+      continue;
+    }
+    const ol = trimmed.match(/^\d+\.\s+(.+)$/);
+    if (ol) {
+      flush();
+      blocks.push(buildBlock(ol[1], "normal", { level: 1, listItem: "number" }));
+      continue;
+    }
+    paragraph.push(trimmed);
+  }
+  flush();
+  return blocks;
+}
+
+const raw = fs.readFileSync(FILE, "utf8");
+const blocks = markdownToPortableText(raw);
+console.log(JSON.stringify(blocks, null, 2));
+console.log(`\n--- total blocks: ${blocks.length} ---`);

--- a/scripts/verify-ai-ui-styling-lesson.ts
+++ b/scripts/verify-ai-ui-styling-lesson.ts
@@ -1,0 +1,57 @@
+/**
+ * 投入された AIxUIスタイリング入門 レッスンを GROQ で取得し、
+ * Quest → Article の参照が正しく連結されているか確認する。
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+async function main() {
+  // getLesson() 相当のクエリ
+  const lesson = await client.fetch(
+    `*[_type == "lesson" && slug.current == $slug][0] {
+      _id, title, slug, description, isPremium, isHidden, tags, purposes,
+      "quests": quests[]-> {
+        _id, questNumber, title, slug, goal,
+        "articles": articles[]-> {
+          _id, articleNumber, articleType, title, slug, excerpt, videoUrl, tags,
+          "blockCount": count(content)
+        }
+      }
+    }`,
+    { slug: "ai-ui-styling-intro" }
+  );
+
+  console.log(JSON.stringify(lesson, null, 2));
+
+  // サマリ
+  console.log("\n=== サマリ ===");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const l = lesson as any;
+  console.log(`Lesson: ${l?.title}  (isHidden=${l?.isHidden}, isPremium=${l?.isPremium})`);
+  console.log(`Quests: ${l?.quests?.length ?? 0}`);
+  let articleTotal = 0;
+  for (const q of l?.quests ?? []) {
+    console.log(
+      `  - Q${q.questNumber}: ${q.title}  / articles=${q.articles?.length ?? 0}`
+    );
+    articleTotal += q.articles?.length ?? 0;
+  }
+  console.log(`Articles total: ${articleTotal}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/achievements/dummy-data.ts
+++ b/src/app/achievements/dummy-data.ts
@@ -1,0 +1,167 @@
+/**
+ * /achievements ハブページ用のダミーデータ
+ *
+ * Sanity スキーマ確定後、実データ取得関数（getStoriesList / getOutputsList）に置き換える。
+ *
+ * アバター: DiceBear lorelei (https://www.dicebear.com/styles/lorelei/) — イラスト風
+ */
+
+const avatar = (seed: string) =>
+  `https://api.dicebear.com/9.x/lorelei/svg?seed=${encodeURIComponent(seed)}&backgroundColor=ffd5dc,ffdfbf,c0aede,d1d4f9,b6e3f4`;
+
+export interface DummyStory {
+  slug: string;
+  title: string;
+  excerpt: string;
+  heroImageUrl: string;
+  category: string;
+  categoryLabel: string;
+  tags: string[];
+  person: {
+    name: string;
+    profileImageUrl?: string;
+    currentRole: string;
+    bio?: string;
+    socialLinks?: { label: string; url: string }[];
+  };
+  publishedAt: string;
+  usedRoadmap?: {
+    title: string;
+    description: string;
+    href: string;
+    imageUrl?: string;
+  };
+}
+
+export interface DummyOutput {
+  id: string;
+  title: string;
+  thumbnailUrl: string;
+  authorName: string;
+  usedContent: {
+    label: string;
+    href: string;
+  };
+  publishedAt: string;
+  externalUrl: string;
+}
+
+export const dummyStories: DummyStory[] = [
+  {
+    slug: "tanaka-yusuke-3months",
+    title: "未経験から3ヶ月でUIデザイナーへ — 田中悠介さんの転職ストーリー",
+    excerpt:
+      "営業職からBONOで学び、3ヶ月で未経験からUIデザイナーへ転職した道のり。",
+    heroImageUrl: "https://placehold.co/800x450/E5E7EB/9CA3AF?text=Story",
+    category: "uiux_career_change",
+    categoryLabel: "UIUX転職",
+    tags: ["未経験"],
+    person: {
+      name: "田中 悠介",
+      profileImageUrl: avatar("tanaka-yusuke"),
+      currentRole: "UIデザイナー @ 株式会社サンプル",
+      bio: "BONOに出会う前は法人営業を5年ほどやっていました。手を動かしてものを作る仕事にずっと憧れがあって、副業で少しずつデザインを始めたのがきっかけです。",
+      socialLinks: [
+        { label: "X", url: "https://x.com/example" },
+        { label: "note", url: "https://note.com/example" },
+        { label: "ポートフォリオ", url: "https://example.com" },
+      ],
+    },
+    publishedAt: "2026-04-12",
+    usedRoadmap: {
+      title: "UIUX転職ロードマップ",
+      description: "未経験から UIデザイナーへの転職を目指すための、12週間の学習プラン",
+      href: "/roadmap/uiux-career-change",
+      imageUrl: "https://placehold.co/400x250/FED7AA/9A3412?text=Roadmap",
+    },
+  },
+  {
+    slug: "sato-misaki-engineer-to-designer",
+    title: "エンジニアからUIUXへ — 佐藤美咲さんのキャリアチェンジ",
+    excerpt:
+      "Webエンジニアとして5年経験を積んだ後、UIUXデザイナーへ職種変更した記録。",
+    heroImageUrl: "https://placehold.co/800x450/E5E7EB/9CA3AF?text=Story",
+    category: "uiux_career_change",
+    categoryLabel: "UIUX転職",
+    tags: ["業界経験あり"],
+    person: {
+      name: "佐藤 美咲",
+      profileImageUrl: avatar("sato-misaki"),
+      currentRole: "プロダクトデザイナー @ 株式会社サンプル",
+    },
+    publishedAt: "2026-03-28",
+  },
+  {
+    slug: "yamamoto-ayano-mom-designer",
+    title: "デザイン未経験のママが、子育てしながら6ヶ月で転職した方法",
+    excerpt:
+      "デザイン経験ゼロ・ワーママの状況からBONOで学び、リモートのUIデザイナーへ。",
+    heroImageUrl: "https://placehold.co/800x450/E5E7EB/9CA3AF?text=Story",
+    category: "uiux_career_change",
+    categoryLabel: "UIUX転職",
+    tags: ["デザイン未経験"],
+    person: {
+      name: "山本 綾乃",
+      profileImageUrl: avatar("yamamoto-ayano"),
+      currentRole: "UIデザイナー（リモート）",
+    },
+    publishedAt: "2026-03-10",
+  },
+];
+
+export const dummyOutputs: DummyOutput[] = [
+  {
+    id: "output-1",
+    title: "BONOのUIスタイリング課題でTwitterのプロフィール画面を作ってみた",
+    thumbnailUrl: "https://placehold.co/600x400/E5E7EB/9CA3AF?text=Output+1",
+    authorName: "中村 大輔",
+    usedContent: { label: "📚 UIUX転職ロードマップ", href: "#" },
+    publishedAt: "2026-05-20",
+    externalUrl: "https://note.com/example/n/sample1",
+  },
+  {
+    id: "output-2",
+    title: "リサーチ課題：銀行アプリを30人にインタビューして気付いたこと",
+    thumbnailUrl: "https://placehold.co/600x400/E5E7EB/9CA3AF?text=Output+2",
+    authorName: "鈴木 健太",
+    usedContent: { label: "📚 UIUX転職ロードマップ", href: "#" },
+    publishedAt: "2026-05-18",
+    externalUrl: "https://note.com/example/n/sample2",
+  },
+  {
+    id: "output-3",
+    title: "Figma で再現！スマホECサイトのカートUI設計プロセス",
+    thumbnailUrl: "https://placehold.co/600x400/E5E7EB/9CA3AF?text=Output+3",
+    authorName: "高橋 舞",
+    usedContent: { label: "🎨 Figma基礎レッスン", href: "#" },
+    publishedAt: "2026-05-15",
+    externalUrl: "https://note.com/example/n/sample3",
+  },
+  {
+    id: "output-4",
+    title: "情報設計の練習として、家計簿アプリをリデザインしてみた",
+    thumbnailUrl: "https://placehold.co/600x400/E5E7EB/9CA3AF?text=Output+4",
+    authorName: "伊藤 翔",
+    usedContent: { label: "📚 情報設計ロードマップ", href: "#" },
+    publishedAt: "2026-05-10",
+    externalUrl: "https://note.com/example/n/sample4",
+  },
+  {
+    id: "output-5",
+    title: "ユーザーテストでわかった、UIの「分かりやすさ」の正体",
+    thumbnailUrl: "https://placehold.co/600x400/E5E7EB/9CA3AF?text=Output+5",
+    authorName: "渡辺 愛",
+    usedContent: { label: "📚 UXデザイン基礎", href: "#" },
+    publishedAt: "2026-05-05",
+    externalUrl: "https://note.com/example/n/sample5",
+  },
+  {
+    id: "output-6",
+    title: "BONOのお題で副業ポートフォリオを3案作った話",
+    thumbnailUrl: "https://placehold.co/600x400/E5E7EB/9CA3AF?text=Output+6",
+    authorName: "松本 陸",
+    usedContent: { label: "🎨 ポートフォリオ強化トピック", href: "#" },
+    publishedAt: "2026-04-30",
+    externalUrl: "https://note.com/example/n/sample6",
+  },
+];

--- a/src/app/achievements/page.tsx
+++ b/src/app/achievements/page.tsx
@@ -1,0 +1,123 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import SectionHeading from "@/components/common/SectionHeading";
+import DottedDivider from "@/components/common/DottedDivider";
+import StoryCardItem from "@/components/story/StoryCardItem";
+import OutputBannerCardItem from "@/components/output/OutputBannerCardItem";
+import { getStoriesList, getOutputsList } from "@/lib/sanity";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "BONOで動き出した人たち",
+  description:
+    "BONOで学んだ受講者の転職ストーリーと、実際に手を動かして生まれたアウトプットを紹介します。",
+  openGraph: {
+    title: "BONOで動き出した人たち | BONO",
+    description:
+      "BONOで学んだ受講者の転職ストーリーと、実際に手を動かして生まれたアウトプットを紹介します。",
+  },
+  twitter: {
+    title: "BONOで動き出した人たち | BONO",
+    description:
+      "BONOで学んだ受講者の転職ストーリーと、実際に手を動かして生まれたアウトプットを紹介します。",
+  },
+  alternates: { canonical: "/achievements" },
+};
+
+export default async function AchievementsPage() {
+  // ストーリーは最新6件（3列 × 2段）、アウトプットは最新6件
+  const [stories, outputs] = await Promise.all([
+    getStoriesList(6),
+    getOutputsList(6),
+  ]);
+
+  return (
+    <div className="min-h-screen">
+      {/* ヒーロー（/guide と同じ独自セクションスタイル、幅はコンテンツに合わせる） */}
+      <section className="px-4 sm:px-6 pt-16 pb-10 max-w-[1200px] mx-auto">
+        <h1 className="text-4xl font-bold font-rounded-mplus mb-4">みんなの成果</h1>
+        <p className="text-muted-foreground text-base leading-relaxed max-w-[600px]">
+          BONOで動き出した人たち
+        </p>
+      </section>
+
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 pb-8 min-w-0">
+
+        {/* ストーリーセクション（縦長グリッド・Discovery 体験） */}
+        <section className="mb-12">
+          <div className="mb-6">
+            <SectionHeading
+              label="STORIES"
+              title="ストーリー"
+              description="受講者が人生を動かした転職ストーリー"
+              showUnderline={false}
+            />
+          </div>
+
+          {stories.length === 0 ? (
+            <p className="text-text-primary/50 text-sm font-noto-sans-jp py-8 text-center">
+              まだストーリーが公開されていません。
+            </p>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+                {stories.map((story) => (
+                  <StoryCardItem key={story._id} story={story} />
+                ))}
+              </div>
+
+              <div className="mt-6 text-right">
+                <Link
+                  href="/stories"
+                  className="inline-flex items-center gap-1 text-sm font-bold text-text-primary hover:opacity-70 transition-opacity font-noto-sans-jp"
+                >
+                  ストーリーをすべて見る
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
+            </>
+          )}
+        </section>
+
+        <DottedDivider className="my-12" />
+
+        {/* アウトプットセクション（横長バナー型・Efficiency 体験） */}
+        <section className="mb-12">
+          <div className="mb-6">
+            <SectionHeading
+              label="OUTPUTS"
+              title="アウトプット"
+              description="BONOのコンテンツを使って生まれた作品・記事たち"
+              showUnderline={false}
+            />
+          </div>
+
+          {outputs.length === 0 ? (
+            <p className="text-text-primary/50 text-sm font-noto-sans-jp py-8 text-center">
+              まだアウトプットが公開されていません。
+            </p>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+                {outputs.map((output) => (
+                  <OutputBannerCardItem key={output._id} output={output} />
+                ))}
+              </div>
+
+              <div className="mt-6 text-right">
+                <Link
+                  href="/outputs"
+                  className="inline-flex items-center gap-1 text-sm font-bold text-text-primary hover:opacity-70 transition-opacity font-noto-sans-jp"
+                >
+                  アウトプットをすべて見る
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/achievements-mixed-banner/page.tsx
+++ b/src/app/dev/achievements-mixed-banner/page.tsx
@@ -1,0 +1,118 @@
+/**
+ * /dev/achievements-mixed-banner — ハブの差別化バリアント（バナー型）
+ *
+ * /achievements ベースで「ストーリー = 縦長グリッド」「アウトプット = 横長バナー型」の
+ * Magazine Layout 風混在。バナー型はユーザー提案サイズ感（横長aspect 2:1）。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import SectionHeading from "@/components/common/SectionHeading";
+import DottedDivider from "@/components/common/DottedDivider";
+import StoryCard from "@/components/story/StoryCard";
+import OutputBannerCard from "@/components/output/OutputBannerCard";
+import { dummyStories, dummyOutputs } from "@/app/achievements/dummy-data";
+
+export const metadata: Metadata = {
+  title: "ハブ Mixed Banner (/dev/achievements-mixed-banner)",
+  robots: { index: false, follow: false },
+};
+
+export default function DevAchievementsMixedBannerPage() {
+  return (
+    <div className="min-h-screen">
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="みんなの成果"
+          title="BONOで動き出した人たち"
+          description="BONOで学んだ受講者の転職ストーリーと、実際に手を動かして生まれたアウトプットを紹介します。"
+        />
+
+        {/* ストーリー = 縦長グリッド */}
+        <section className="mb-12">
+          <div className="mb-6">
+            <SectionHeading
+              label="STORIES"
+              title="ストーリー"
+              description="受講者が人生を動かした転職ストーリー"
+              showUnderline={false}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {dummyStories.map((s) => (
+              <StoryCard
+                key={s.slug}
+                slug={s.slug}
+                title={s.title}
+                excerpt={s.excerpt}
+                heroImageUrl={s.heroImageUrl}
+                categoryLabel={s.categoryLabel}
+                tags={s.tags}
+                person={s.person}
+              />
+            ))}
+          </div>
+
+          <div className="mt-6 text-right">
+            <Link
+              href="/stories"
+              className="inline-flex items-center gap-1 text-sm font-bold text-text-primary hover:opacity-70 transition-opacity font-noto-sans-jp"
+            >
+              ストーリーをすべて見る
+              <span aria-hidden>→</span>
+            </Link>
+          </div>
+        </section>
+
+        <DottedDivider className="my-12" />
+
+        {/* アウトプット = 横長バナー（aspect 2:1） */}
+        <section className="mb-12">
+          <div className="mb-6">
+            <SectionHeading
+              label="OUTPUTS"
+              title="アウトプット"
+              description="BONOのコンテンツを使って生まれた作品・記事たち"
+              showUnderline={false}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {dummyOutputs.map((o) => (
+              <OutputBannerCard
+                key={o.id}
+                title={o.title}
+                thumbnailUrl={o.thumbnailUrl}
+                authorName={o.authorName}
+                usedContent={o.usedContent}
+                publishedAt={o.publishedAt}
+                externalUrl={o.externalUrl}
+              />
+            ))}
+          </div>
+
+          <div className="mt-6 text-right">
+            <Link
+              href="/outputs"
+              className="inline-flex items-center gap-1 text-sm font-bold text-text-primary hover:opacity-70 transition-opacity font-noto-sans-jp"
+            >
+              アウトプットをすべて見る
+              <span aria-hidden>→</span>
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/achievements-mixed/page.tsx
+++ b/src/app/dev/achievements-mixed/page.tsx
@@ -1,0 +1,119 @@
+/**
+ * /dev/achievements-mixed — ハブの差別化バリアント
+ *
+ * /achievements ベースで「ストーリー = グリッド」「アウトプット = リスト型」の
+ * Magazine Layout 風混在。リサーチ推し: Cards = discovery / Lists = efficiency。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import SectionHeading from "@/components/common/SectionHeading";
+import DottedDivider from "@/components/common/DottedDivider";
+import StoryCard from "@/components/story/StoryCard";
+import OutputListItem from "@/components/output/OutputListItem";
+import { dummyStories, dummyOutputs } from "@/app/achievements/dummy-data";
+
+export const metadata: Metadata = {
+  title: "ハブ Mixed Layout (/dev/achievements-mixed)",
+  robots: { index: false, follow: false },
+};
+
+export default function DevAchievementsMixedPage() {
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="みんなの成果"
+          title="BONOで動き出した人たち"
+          description="BONOで学んだ受講者の転職ストーリーと、実際に手を動かして生まれたアウトプットを紹介します。"
+        />
+
+        {/* ストーリー = グリッド型カード（じっくり選ぶ・Discovery体験） */}
+        <section className="mb-12">
+          <div className="mb-6">
+            <SectionHeading
+              label="STORIES"
+              title="ストーリー"
+              description="受講者が人生を動かした転職ストーリー"
+              showUnderline={false}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {dummyStories.map((s) => (
+              <StoryCard
+                key={s.slug}
+                slug={s.slug}
+                title={s.title}
+                excerpt={s.excerpt}
+                heroImageUrl={s.heroImageUrl}
+                categoryLabel={s.categoryLabel}
+                tags={s.tags}
+                person={s.person}
+              />
+            ))}
+          </div>
+
+          <div className="mt-6 text-right">
+            <Link
+              href="/stories"
+              className="inline-flex items-center gap-1 text-sm font-bold text-text-primary hover:opacity-70 transition-opacity font-noto-sans-jp"
+            >
+              ストーリーをすべて見る
+              <span aria-hidden>→</span>
+            </Link>
+          </div>
+        </section>
+
+        <DottedDivider className="my-12" />
+
+        {/* アウトプット = リスト型（流し読み・Efficiency体験） */}
+        <section className="mb-12">
+          <div className="mb-6">
+            <SectionHeading
+              label="OUTPUTS"
+              title="アウトプット"
+              description="BONOのコンテンツを使って生まれた作品・記事たち"
+              showUnderline={false}
+            />
+          </div>
+
+          <div className="flex flex-col gap-3 max-w-3xl">
+            {dummyOutputs.map((o) => (
+              <OutputListItem
+                key={o.id}
+                title={o.title}
+                thumbnailUrl={o.thumbnailUrl}
+                authorName={o.authorName}
+                usedContent={o.usedContent}
+                publishedAt={o.publishedAt}
+                externalUrl={o.externalUrl}
+              />
+            ))}
+          </div>
+
+          <div className="mt-6 text-right max-w-3xl">
+            <Link
+              href="/outputs"
+              className="inline-flex items-center gap-1 text-sm font-bold text-text-primary hover:opacity-70 transition-opacity font-noto-sans-jp"
+            >
+              アウトプットをすべて見る
+              <span aria-hidden>→</span>
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/bon-327/page.tsx
+++ b/src/app/dev/bon-327/page.tsx
@@ -1,0 +1,235 @@
+/**
+ * /dev — デザインパターン確認ポータル
+ *
+ * 各カテゴリの検証ページへのインデックス。
+ * 本番には出さない、開発中の検討用。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Design Pattern Portal (/dev)",
+  robots: { index: false, follow: false },
+};
+
+interface PatternEntry {
+  href: string;
+  category: string;
+  title: string;
+  description: string;
+  status: "ready" | "wip";
+}
+
+const entries: PatternEntry[] = [
+  // === /stories まわり ===
+  {
+    href: "/dev/stories-list",
+    category: "📖 /stories（ストーリー）",
+    title: "一覧ページ 叩き（カードB版）",
+    description:
+      "PageHeader + タグフィルタ + カードグリッド（カードB: 画像+タイトル+名前+職種）+ /outputs への回遊CTA。",
+    status: "ready",
+  },
+  {
+    href: "/dev/stories-list-a",
+    category: "📖 /stories（ストーリー）",
+    title: "一覧ページ（カードA + 概要なし版）",
+    description:
+      "同じレイアウトでカードを最小化版（画像+タイトル+名前のみ）に。最もシンプルな一覧体験。",
+    status: "ready",
+  },
+  {
+    href: "/dev/story-card",
+    category: "📖 /stories（ストーリー）",
+    title: "カード パターン比較（現状版 / A / B / C）",
+    description: "一覧カードの要素削減方針を決めるための4種比較。",
+    status: "ready",
+  },
+  {
+    href: "/dev/story-detail-a",
+    category: "📖 /stories（ストーリー）",
+    title: "詳細ページ パターン1（/blog 完全踏襲）",
+    description:
+      "/blog レイアウト完全踏襲。人物・bio・SNS・ロードマップは本文中に埋め込む。統一感MAX、実装最小。",
+    status: "ready",
+  },
+  {
+    href: "/dev/story-detail",
+    category: "📖 /stories（ストーリー）",
+    title: "詳細ページ パターン2（プロフカード強化）★推し",
+    description:
+      "/blog ベース + 人物プロフィールカードを独立ブロック化。使ったロードマップも独立カード。",
+    status: "ready",
+  },
+  {
+    href: "/dev/story-detail-c",
+    category: "📖 /stories（ストーリー）",
+    title: "詳細ページ パターン3（物語性強化）",
+    description:
+      "Heroオーバーレイで人物名・ビフォー/アフター強調。Pull Quote で物語性最大化。",
+    status: "ready",
+  },
+  {
+    href: "/dev/story-detail-d",
+    category: "📖 /stories（ストーリー）",
+    title: "詳細ページ パターン4（Figma Blog風タイポ）★Figma参照",
+    description:
+      "余白たっぷり・本文 16px/lh 1.85・H1 56px・本文幅 700px。背景 #f9f9f7、本文色 #354540。Figma の PROD-Guide-Blog_2026 のスタイル踏襲。",
+    status: "ready",
+  },
+
+  // === /outputs まわり ===
+  {
+    href: "/dev/outputs-list",
+    category: "✏️ /outputs（アウトプット）",
+    title: "一覧ページ 叩き（グリッド版）",
+    description:
+      "現状版：縦長カードのグリッド。/stories と形が似ている。",
+    status: "ready",
+  },
+  {
+    href: "/dev/outputs-list-list",
+    category: "✏️ /outputs（アウトプット）",
+    title: "一覧ページ（リスト型バリアント）★リサーチ推し",
+    description:
+      "Zapier/Intercom/Substack list view 風の横長カード。流し読みに最適。/stories との形状差で一目区別。",
+    status: "ready",
+  },
+  {
+    href: "/dev/output-card",
+    category: "✏️ /outputs（アウトプット）",
+    title: "カード パターン比較（現状版 / リスト型）",
+    description:
+      "縦長カード（現状）と横長リスト型を並べて比較。",
+    status: "ready",
+  },
+
+  // === ハブ ===
+  {
+    href: "/dev/achievements-mixed",
+    category: "🏠 /achievements（ハブ）",
+    title: "ストーリー=グリッド × アウトプット=リスト型（Mixed）",
+    description:
+      "Magazine Layout 風。リスト型は流し読み最適化。/stories との形状差で一目区別。",
+    status: "ready",
+  },
+  {
+    href: "/dev/achievements-mixed-banner",
+    category: "🏠 /achievements（ハブ）",
+    title: "ストーリー=グリッド × アウトプット=バナー型 ★ユーザー提案",
+    description:
+      "アウトプットを横長バナー型（aspect 2:1）で配置。サムネを大きく見せて note 記事のキャッチー感を保ちつつ、/stories と形状で差別化。",
+    status: "ready",
+  },
+];
+
+function StatusBadge({ status }: { status: PatternEntry["status"] }) {
+  if (status === "ready") {
+    return (
+      <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-noto-sans-jp">
+        Ready
+      </span>
+    );
+  }
+  return (
+    <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-700 font-noto-sans-jp">
+      WIP
+    </span>
+  );
+}
+
+export default function DevPortalPage() {
+  // カテゴリごとにグルーピング
+  const grouped = entries.reduce<Record<string, PatternEntry[]>>((acc, e) => {
+    if (!acc[e.category]) acc[e.category] = [];
+    acc[e.category].push(e);
+    return acc;
+  }, {});
+
+  return (
+    <div className="min-h-screen bg-base">
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <header className="mb-12 pb-6 border-b-2 border-gray-300">
+          <p className="text-sm font-bold text-text-primary/50 font-noto-sans-jp">
+            INTERNAL
+          </p>
+          <h1 className="text-2xl sm:text-3xl font-bold text-text-primary font-rounded-mplus mt-1">
+            Design Pattern Portal
+          </h1>
+          <p className="text-sm text-text-primary/60 mt-2 font-noto-sans-jp leading-relaxed">
+            デザインパターン・プロトタイプの検証用ページ。本番には公開されない。
+            <br />
+            BON-327 / BON-345 のスタイル選定で使用。
+          </p>
+        </header>
+
+        {Object.entries(grouped).map(([category, items]) => (
+          <section key={category} className="mb-12">
+            <h2 className="text-xs font-bold text-text-primary/50 font-noto-sans-jp mb-4 tracking-wider">
+              {category.toUpperCase()}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {items.map((entry) => (
+                <Link
+                  key={entry.href}
+                  href={entry.href}
+                  className="group block bg-surface rounded-[20px] border border-gray-200/60 shadow-sm p-6 hover:shadow-md hover:border-gray-300 transition-all"
+                >
+                  <div className="flex items-center justify-between gap-2 mb-2">
+                    <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus group-hover:underline">
+                      {entry.title}
+                    </h3>
+                    <StatusBadge status={entry.status} />
+                  </div>
+                  <p className="text-sm text-text-primary/70 font-noto-sans-jp leading-relaxed">
+                    {entry.description}
+                  </p>
+                  <p className="text-xs text-text-primary/40 mt-3 font-noto-sans-jp">
+                    {entry.href} →
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        {/* 参考リンク */}
+        <section className="mt-16 pt-6 border-t border-gray-200">
+          <h2 className="text-xs font-bold text-text-primary/50 font-noto-sans-jp mb-4 tracking-wider">
+            REFERENCE
+          </h2>
+          <ul className="space-y-2 text-sm font-noto-sans-jp">
+            <li>
+              <Link
+                href="/achievements"
+                className="text-text-primary hover:underline"
+              >
+                /achievements
+              </Link>
+              <span className="text-text-primary/50 ml-2">
+                ハブページ（現状版）
+              </span>
+            </li>
+            <li>
+              <Link href="/lessons" className="text-text-primary hover:underline">
+                /lessons
+              </Link>
+              <span className="text-text-primary/50 ml-2">
+                参照: 一覧ページ・幅・PageHeader
+              </span>
+            </li>
+            <li>
+              <Link href="/blog" className="text-text-primary hover:underline">
+                /blog
+              </Link>
+              <span className="text-text-primary/50 ml-2">
+                参照: 記事詳細レイアウト
+              </span>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/output-card/page.tsx
+++ b/src/app/dev/output-card/page.tsx
@@ -1,0 +1,114 @@
+/**
+ * /dev/output-card — OutputCard パターン確認
+ *
+ * 15分FB済みアウトプットのカード表示確認用。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import { dummyOutputs } from "@/app/achievements/dummy-data";
+import OutputCard from "@/components/output/OutputCard";
+import OutputListItem from "@/components/output/OutputListItem";
+import OutputBannerCard from "@/components/output/OutputBannerCard";
+
+export const metadata: Metadata = {
+  title: "OutputCard パターン確認 (/dev/output-card)",
+  robots: { index: false, follow: false },
+};
+
+export default function DevOutputCardPage() {
+  return (
+    <div className="min-h-screen bg-base">
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <header className="mb-12 pb-6 border-b-2 border-gray-300">
+          <Link
+            href="/dev/bon-327"
+            className="text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+          </Link>
+          <h1 className="text-2xl font-bold text-text-primary font-rounded-mplus mt-2">
+            OutputCard パターン確認
+          </h1>
+          <p className="text-sm text-text-primary/60 mt-1 font-noto-sans-jp">
+            15分FB済みアウトプット記事のカード表示
+          </p>
+        </header>
+
+        <section className="mb-16">
+          <div className="mb-4 pb-3 border-b border-gray-200">
+            <h2 className="text-xl font-bold text-text-primary font-rounded-mplus">
+              現状版（縦長グリッドカード・5要素）
+            </h2>
+            <p className="text-sm text-text-primary/60 mt-1 font-noto-sans-jp">
+              サムネ + タイトル + 投稿者 + 日付 + 使ったコンテンツ。/stories と形が似ている。
+            </p>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-6">
+            {dummyOutputs.map((o) => (
+              <OutputCard
+                key={o.id}
+                title={o.title}
+                thumbnailUrl={o.thumbnailUrl}
+                authorName={o.authorName}
+                usedContent={o.usedContent}
+                publishedAt={o.publishedAt}
+                externalUrl={o.externalUrl}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <div className="mb-4 pb-3 border-b border-gray-200">
+            <h2 className="text-xl font-bold text-text-primary font-rounded-mplus">
+              リスト型（横長カード・Zapier/Intercom/Substack風）★リサーチ推し
+            </h2>
+            <p className="text-sm text-text-primary/60 mt-1 font-noto-sans-jp">
+              サムネ左 + テキスト右の横長レイアウト。1列縦並びで流し読みに最適。
+              /stories の縦長グリッドと形状が完全に違うので一目で区別できる。
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 max-w-3xl">
+            {dummyOutputs.map((o) => (
+              <OutputListItem
+                key={o.id}
+                title={o.title}
+                thumbnailUrl={o.thumbnailUrl}
+                authorName={o.authorName}
+                usedContent={o.usedContent}
+                publishedAt={o.publishedAt}
+                externalUrl={o.externalUrl}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <div className="mb-4 pb-3 border-b border-gray-200">
+            <h2 className="text-xl font-bold text-text-primary font-rounded-mplus">
+              バナー型（横長グリッド・aspect 2:1）★ユーザー提案
+            </h2>
+            <p className="text-sm text-text-primary/60 mt-1 font-noto-sans-jp">
+              横長サムネ（2:1）を大きく見せるグリッドカード。2〜3列配置で、note記事のOGP画像が映える。
+              /stories の縦長グリッドとはアスペクト比が違うので形状で区別できる。
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {dummyOutputs.map((o) => (
+              <OutputBannerCard
+                key={o.id}
+                title={o.title}
+                thumbnailUrl={o.thumbnailUrl}
+                authorName={o.authorName}
+                usedContent={o.usedContent}
+                publishedAt={o.publishedAt}
+                externalUrl={o.externalUrl}
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/outputs-list-list/page.tsx
+++ b/src/app/dev/outputs-list-list/page.tsx
@@ -1,0 +1,113 @@
+/**
+ * /dev/outputs-list-list — アウトプット一覧（リスト型バリアント）
+ *
+ * /dev/outputs-list と同じレイアウトベース、カードをリスト型（横長）に差し替え。
+ * リサーチ推し: Zapier / Intercom / Substack list view の流し読み体験。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import { dummyOutputs } from "@/app/achievements/dummy-data";
+import OutputListItem from "@/components/output/OutputListItem";
+
+export const metadata: Metadata = {
+  title: "アウトプット一覧 リスト型 (/dev/outputs-list-list)",
+  robots: { index: false, follow: false },
+};
+
+const contentFilters = [
+  "すべて",
+  "UIUX転職ロードマップ",
+  "情報設計ロードマップ",
+  "UXデザイン基礎",
+  "Figma基礎レッスン",
+  "ポートフォリオ強化トピック",
+];
+
+export default function DevOutputsListListPage() {
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="OUTPUTS"
+          title="アウトプット一覧"
+          description="BONOのコンテンツを使った受講者が、実際に書いた記事を集めた場所。"
+        />
+
+        <div className="mb-6">
+          <Link
+            href="/achievements"
+            className="inline-flex items-center gap-1 text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← みんなの成果 に戻る
+          </Link>
+        </div>
+
+        {/* 使ったコンテンツフィルタ */}
+        <div className="mb-8 flex flex-wrap gap-2">
+          {contentFilters.map((label, i) => (
+            <button
+              key={label}
+              type="button"
+              className={`text-sm px-4 py-2 rounded-full font-noto-sans-jp transition-colors ${
+                i === 0
+                  ? "bg-text-primary text-white font-bold"
+                  : "bg-muted-custom text-text-primary/70 hover:bg-gray-200"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* リスト型・1列縦並び */}
+        <div className="flex flex-col gap-3 max-w-3xl">
+          {dummyOutputs.map((o) => (
+            <OutputListItem
+              key={o.id}
+              title={o.title}
+              thumbnailUrl={o.thumbnailUrl}
+              authorName={o.authorName}
+              usedContent={o.usedContent}
+              publishedAt={o.publishedAt}
+              externalUrl={o.externalUrl}
+            />
+          ))}
+        </div>
+
+        <div className="mt-12 text-center text-sm text-text-primary/50 font-noto-sans-jp">
+          ※ 件数増えたらページネーション or 無限スクロールを実装
+        </div>
+
+        {/* 回遊CTA: /stories へ */}
+        <div className="mt-16 pt-12 border-t border-gray-200/60">
+          <Link
+            href="/stories"
+            className="group block bg-surface rounded-[24px] border border-gray-200/60 shadow-sm p-6 sm:p-8 hover:shadow-md hover:border-gray-300 transition-all max-w-2xl mx-auto"
+          >
+            <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+              受講者ストーリー
+            </p>
+            <h3 className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus mt-1">
+              人生を動かした受講者のインタビューも読んでみる →
+            </h3>
+            <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2">
+              転職・独立など、BONOで動き出した人たちのストーリー集。
+            </p>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/outputs-list/page.tsx
+++ b/src/app/dev/outputs-list/page.tsx
@@ -1,0 +1,116 @@
+/**
+ * /dev/outputs-list — アウトプット専用一覧ページの叩き
+ *
+ * 15分FB済みアウトプット記事の一覧。
+ * /lessons の幅・PageHeader と揃える。
+ * カード密度高め（4列）でブラウジング体験。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import { dummyOutputs } from "@/app/achievements/dummy-data";
+import OutputCard from "@/components/output/OutputCard";
+
+export const metadata: Metadata = {
+  title: "アウトプット一覧 叩き (/dev/outputs-list)",
+  robots: { index: false, follow: false },
+};
+
+// 使ったコンテンツ別フィルタ（仮）
+const contentFilters = [
+  "すべて",
+  "UIUX転職ロードマップ",
+  "情報設計ロードマップ",
+  "UXデザイン基礎",
+  "Figma基礎レッスン",
+  "ポートフォリオ強化トピック",
+];
+
+export default function DevOutputsListPage() {
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="OUTPUTS"
+          title="アウトプット一覧"
+          description="BONOのコンテンツを使った受講者が、実際に書いた記事を集めた場所。"
+        />
+
+        {/* 戻りナビ */}
+        <div className="mb-6">
+          <Link
+            href="/achievements"
+            className="inline-flex items-center gap-1 text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← みんなの成果 に戻る
+          </Link>
+        </div>
+
+        {/* 使ったコンテンツフィルタ */}
+        <div className="mb-8 flex flex-wrap gap-2">
+          {contentFilters.map((label, i) => (
+            <button
+              key={label}
+              type="button"
+              className={`text-sm px-4 py-2 rounded-full font-noto-sans-jp transition-colors ${
+                i === 0
+                  ? "bg-text-primary text-white font-bold"
+                  : "bg-muted-custom text-text-primary/70 hover:bg-gray-200"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* アウトプットグリッド（密度高め: 4列 lg） */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-5">
+          {dummyOutputs.map((o) => (
+            <OutputCard
+              key={o.id}
+              title={o.title}
+              thumbnailUrl={o.thumbnailUrl}
+              authorName={o.authorName}
+              usedContent={o.usedContent}
+              publishedAt={o.publishedAt}
+              externalUrl={o.externalUrl}
+            />
+          ))}
+        </div>
+
+        <div className="mt-12 text-center text-sm text-text-primary/50 font-noto-sans-jp">
+          ※ 件数増えたらページネーション or 無限スクロールを実装
+        </div>
+
+        {/* 回遊CTA: /stories へ */}
+        <div className="mt-16 pt-12 border-t border-gray-200/60">
+          <Link
+            href="/stories"
+            className="group block bg-surface rounded-[24px] border border-gray-200/60 shadow-sm p-6 sm:p-8 hover:shadow-md hover:border-gray-300 transition-all max-w-2xl mx-auto"
+          >
+            <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+              受講者ストーリー
+            </p>
+            <h3 className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus mt-1">
+              人生を動かした受講者のインタビューも読んでみる →
+            </h3>
+            <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2">
+              転職・独立など、BONOで動き出した人たちのストーリー集。
+            </p>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -1,0 +1,110 @@
+/**
+ * /dev — 内部用デザイン検討ポータル（上位）
+ *
+ * 過去・現在のデザイン検討プロセスをまとめる。
+ * 個別の検討は `/dev/<issue-id>` 配下に配置。
+ * 本番には出さない（noindex）。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Dev Portal (/dev)",
+  robots: { index: false, follow: false },
+};
+
+interface DevProjectEntry {
+  href: string;
+  issue: string;
+  title: string;
+  summary: string;
+  status: "in-progress" | "shipped" | "archived";
+}
+
+const projects: DevProjectEntry[] = [
+  {
+    href: "/dev/bon-327",
+    issue: "BON-327",
+    title: "受講者ストーリー & アウトプット まわり",
+    summary:
+      "/achievements ハブ・/stories 一覧&詳細・/outputs 一覧の検討プロセス。カード/詳細ページの複数パターン比較。",
+    status: "shipped",
+  },
+];
+
+function StatusBadge({ status }: { status: DevProjectEntry["status"] }) {
+  if (status === "shipped") {
+    return (
+      <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-noto-sans-jp">
+        Shipped
+      </span>
+    );
+  }
+  if (status === "in-progress") {
+    return (
+      <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-700 font-noto-sans-jp">
+        In Progress
+      </span>
+    );
+  }
+  return (
+    <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 font-noto-sans-jp">
+      Archived
+    </span>
+  );
+}
+
+export default function DevPortalPage() {
+  return (
+    <div className="min-h-screen bg-base">
+      <div className="max-w-[960px] w-full mx-auto px-4 sm:px-6 py-12 min-w-0">
+        <header className="mb-12 pb-6 border-b-2 border-gray-300">
+          <p className="text-sm font-bold text-text-primary/50 font-noto-sans-jp">
+            INTERNAL
+          </p>
+          <h1 className="text-2xl sm:text-3xl font-bold text-text-primary font-rounded-mplus mt-1">
+            Dev Portal
+          </h1>
+          <p className="text-sm text-text-primary/60 mt-2 font-noto-sans-jp leading-relaxed">
+            デザイン検討プロセスのアーカイブ。Issue ごとに検討ページをまとめている。
+            本番には公開されない（noindex）。
+          </p>
+        </header>
+
+        <section>
+          <h2 className="text-xs font-bold text-text-primary/50 font-noto-sans-jp mb-4 tracking-wider">
+            PROJECTS
+          </h2>
+          <div className="grid grid-cols-1 gap-4">
+            {projects.map((entry) => (
+              <Link
+                key={entry.href}
+                href={entry.href}
+                className="group block bg-surface rounded-[20px] border border-gray-200/60 shadow-sm p-6 hover:shadow-md hover:border-gray-300 transition-all"
+              >
+                <div className="flex items-center justify-between gap-2 mb-2">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="text-xs font-bold text-text-primary/40 font-noto-sans-jp tracking-wider flex-shrink-0">
+                      {entry.issue}
+                    </span>
+                    <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus group-hover:underline truncate">
+                      {entry.title}
+                    </h3>
+                  </div>
+                  <StatusBadge status={entry.status} />
+                </div>
+                <p className="text-sm text-text-primary/70 font-noto-sans-jp leading-relaxed">
+                  {entry.summary}
+                </p>
+                <p className="text-xs text-text-primary/40 mt-3 font-noto-sans-jp">
+                  {entry.href} →
+                </p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/stories-list-a/page.tsx
+++ b/src/app/dev/stories-list-a/page.tsx
@@ -1,0 +1,105 @@
+/**
+ * /dev/stories-list-a — ストーリー一覧（カードA + 概要なし版）
+ *
+ * /dev/stories-list と同じレイアウトベース、カードを「パターンA（最小化）」に差し替え。
+ * 概要文・職種・タグは出さない。シンプル特化版。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import { dummyStories } from "@/app/achievements/dummy-data";
+import StoryCardPatternA from "@/components/story/_patterns/StoryCardPatternA";
+
+export const metadata: Metadata = {
+  title: "ストーリー一覧 / カードA + 概要なし (/dev/stories-list-a)",
+  robots: { index: false, follow: false },
+};
+
+const tagFilters = ["すべて", "未経験", "業界経験あり", "デザイン未経験"];
+
+export default function DevStoriesListAPage() {
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="STORIES"
+          title="ストーリー一覧"
+          description="BONOで学んで人生を動かした受講者たちのインタビュー記事。"
+        />
+
+        {/* 戻りナビ */}
+        <div className="mb-6">
+          <Link
+            href="/achievements"
+            className="inline-flex items-center gap-1 text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← みんなの成果 に戻る
+          </Link>
+        </div>
+
+        {/* タグフィルタ */}
+        <div className="mb-8 flex flex-wrap gap-2">
+          {tagFilters.map((tag, i) => (
+            <button
+              key={tag}
+              type="button"
+              className={`text-sm px-4 py-2 rounded-full font-noto-sans-jp transition-colors ${
+                i === 0
+                  ? "bg-text-primary text-white font-bold"
+                  : "bg-muted-custom text-text-primary/70 hover:bg-gray-200"
+              }`}
+            >
+              {i === 0 ? tag : `#${tag}`}
+            </button>
+          ))}
+        </div>
+
+        {/* ストーリーグリッド（カードA: 画像 + タイトル + 名前のみ） */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+          {dummyStories.map((s) => (
+            <StoryCardPatternA
+              key={s.slug}
+              slug={s.slug}
+              title={s.title}
+              heroImageUrl={s.heroImageUrl}
+              person={s.person}
+            />
+          ))}
+        </div>
+
+        <div className="mt-12 text-center text-sm text-text-primary/50 font-noto-sans-jp">
+          ※ 件数増えたらページネーション or 「もっと読み込む」を実装
+        </div>
+
+        {/* 回遊CTA: /outputs へ */}
+        <div className="mt-16 pt-12 border-t border-gray-200/60">
+          <Link
+            href="/outputs"
+            className="group block bg-surface rounded-[24px] border border-gray-200/60 shadow-sm p-6 sm:p-8 hover:shadow-md hover:border-gray-300 transition-all max-w-2xl mx-auto"
+          >
+            <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+              みんなのアウトプット
+            </p>
+            <h3 className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus mt-1">
+              受講者が実際に書いたアウトプット記事も見てみる →
+            </h3>
+            <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2">
+              15分FBを受けた記事の一覧。「こういう使い方もできるんだ」が分かる。
+            </p>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/stories-list/page.tsx
+++ b/src/app/dev/stories-list/page.tsx
@@ -1,0 +1,107 @@
+/**
+ * /dev/stories-list — ストーリー専用一覧ページの叩き
+ *
+ * /lessons のレイアウト・幅・PageHeader と揃える。
+ * フィルタは tags のチップ（軸1: 経験背景）のみ。MVP方針。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import { dummyStories } from "@/app/achievements/dummy-data";
+import StoryCardPatternB from "@/components/story/_patterns/StoryCardPatternB";
+
+export const metadata: Metadata = {
+  title: "ストーリー一覧 叩き (/dev/stories-list)",
+  robots: { index: false, follow: false },
+};
+
+// 軸1: 経験背景タグ（初期）
+const tagFilters = ["すべて", "未経験", "業界経験あり", "デザイン未経験"];
+
+export default function DevStoriesListPage() {
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="STORIES"
+          title="ストーリー一覧"
+          description="BONOで学んで人生を動かした受講者たちのインタビュー記事。"
+        />
+
+        {/* 戻りナビ（/achievements へ） */}
+        <div className="mb-6">
+          <Link
+            href="/achievements"
+            className="inline-flex items-center gap-1 text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← みんなの成果 に戻る
+          </Link>
+        </div>
+
+        {/* タグフィルタ（チップ） */}
+        <div className="mb-8 flex flex-wrap gap-2">
+          {tagFilters.map((tag, i) => (
+            <button
+              key={tag}
+              type="button"
+              className={`text-sm px-4 py-2 rounded-full font-noto-sans-jp transition-colors ${
+                i === 0
+                  ? "bg-text-primary text-white font-bold"
+                  : "bg-muted-custom text-text-primary/70 hover:bg-gray-200"
+              }`}
+            >
+              {i === 0 ? tag : `#${tag}`}
+            </button>
+          ))}
+        </div>
+
+        {/* ストーリーグリッド */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+          {dummyStories.map((s) => (
+            <StoryCardPatternB
+              key={s.slug}
+              slug={s.slug}
+              title={s.title}
+              heroImageUrl={s.heroImageUrl}
+              person={s.person}
+            />
+          ))}
+        </div>
+
+        {/* 件数が増えたとき: ページネーション or 「もっと読み込む」を後で追加 */}
+        <div className="mt-12 text-center text-sm text-text-primary/50 font-noto-sans-jp">
+          ※ 件数増えたらページネーション or 「もっと読み込む」を実装
+        </div>
+
+        {/* 回遊CTA: /outputs へ */}
+        <div className="mt-16 pt-12 border-t border-gray-200/60">
+          <Link
+            href="/outputs"
+            className="group block bg-surface rounded-[24px] border border-gray-200/60 shadow-sm p-6 sm:p-8 hover:shadow-md hover:border-gray-300 transition-all max-w-2xl mx-auto"
+          >
+            <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+              みんなのアウトプット
+            </p>
+            <h3 className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus mt-1">
+              受講者が実際に書いたアウトプット記事も見てみる →
+            </h3>
+            <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2">
+              15分FBを受けた記事の一覧。「こういう使い方もできるんだ」が分かる。
+            </p>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/story-card/page.tsx
+++ b/src/app/dev/story-card/page.tsx
@@ -1,0 +1,137 @@
+/**
+ * /dev/story-card — StoryCard パターン比較
+ *
+ * 現状版（全要素入り）と削減パターン A / B / C を並べて比較する。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import { dummyStories } from "@/app/achievements/dummy-data";
+import StoryCard from "@/components/story/StoryCard";
+import StoryCardPatternA from "@/components/story/_patterns/StoryCardPatternA";
+import StoryCardPatternB from "@/components/story/_patterns/StoryCardPatternB";
+import StoryCardPatternC from "@/components/story/_patterns/StoryCardPatternC";
+
+export const metadata: Metadata = {
+  title: "StoryCard パターン比較 (/dev/story-card)",
+  robots: { index: false, follow: false },
+};
+
+function PatternSection({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-16">
+      <div className="mb-4 pb-3 border-b border-gray-200">
+        <h2 className="text-xl font-bold text-text-primary font-rounded-mplus">
+          {label}
+        </h2>
+        <p className="text-sm text-text-primary/60 mt-1 font-noto-sans-jp">
+          {description}
+        </p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export default function DevStoryCardPage() {
+  return (
+    <div className="min-h-screen bg-base">
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <header className="mb-12 pb-6 border-b-2 border-gray-300">
+          <Link
+            href="/dev/bon-327"
+            className="text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+          </Link>
+          <h1 className="text-2xl font-bold text-text-primary font-rounded-mplus mt-2">
+            StoryCard パターン比較
+          </h1>
+          <p className="text-sm text-text-primary/60 mt-1 font-noto-sans-jp">
+            一覧カードの要素削減方針を決めるための検証
+          </p>
+        </header>
+
+        <PatternSection
+          label="現状版（全要素入り・8要素）"
+          description="アイキャッチ + カテゴリ + タイトル + リード文 + プロフ画像 + 名前 + 職種 + タグ"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {dummyStories.map((s) => (
+              <StoryCard
+                key={s.slug}
+                slug={s.slug}
+                title={s.title}
+                excerpt={s.excerpt}
+                heroImageUrl={s.heroImageUrl}
+                categoryLabel={s.categoryLabel}
+                tags={s.tags}
+                person={s.person}
+              />
+            ))}
+          </div>
+        </PatternSection>
+
+        <PatternSection
+          label="パターンA（最小化・3要素）"
+          description="アイキャッチ + タイトル + 名前 のみ。最もシンプル"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {dummyStories.map((s) => (
+              <StoryCardPatternA
+                key={s.slug}
+                slug={s.slug}
+                title={s.title}
+                heroImageUrl={s.heroImageUrl}
+                person={s.person}
+              />
+            ))}
+          </div>
+        </PatternSection>
+
+        <PatternSection
+          label="パターンB（中庸・4要素）★推し"
+          description="アイキャッチ + タイトル + 名前 + 職種。「誰がどう変わったか」が伝わる"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {dummyStories.map((s) => (
+              <StoryCardPatternB
+                key={s.slug}
+                slug={s.slug}
+                title={s.title}
+                heroImageUrl={s.heroImageUrl}
+                person={s.person}
+              />
+            ))}
+          </div>
+        </PatternSection>
+
+        <PatternSection
+          label="パターンC（タグ残す・4要素）"
+          description="アイキャッチ + タイトル + 名前 + タグ。属性ベースの導線あり"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {dummyStories.map((s) => (
+              <StoryCardPatternC
+                key={s.slug}
+                slug={s.slug}
+                title={s.title}
+                heroImageUrl={s.heroImageUrl}
+                tags={s.tags}
+                person={s.person}
+              />
+            ))}
+          </div>
+        </PatternSection>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/story-detail-a/page.tsx
+++ b/src/app/dev/story-detail-a/page.tsx
@@ -1,0 +1,225 @@
+/**
+ * /dev/story-detail-a — ストーリー詳細 パターン1（/blog 完全踏襲版）
+ *
+ * ストーリー固有情報（人物・bio・SNS・使ったロードマップ）は
+ * すべて本文中の見出し下に普通に埋め込む。
+ * /blog のレイアウトと完全に揃え、統一感を最大化する叩き。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { dummyStories } from "@/app/achievements/dummy-data";
+import StoryCardPatternB from "@/components/story/_patterns/StoryCardPatternB";
+
+export const metadata: Metadata = {
+  title: "ストーリー詳細 パターン1（/blog 完全踏襲） (/dev/story-detail-a)",
+  robots: { index: false, follow: false },
+};
+
+export default function DevStoryDetailAPage() {
+  const story = dummyStories[0];
+  const relatedStories = dummyStories.slice(1, 3);
+
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <main className="container mx-auto px-4 sm:px-6 pb-16">
+        <div className="max-w-4xl mx-auto">
+          {/* パンくず */}
+          <nav className="pt-6 pb-4 text-sm text-text-primary/60 font-noto-sans-jp">
+            <Link href="/achievements" className="hover:underline">
+              みんなの成果
+            </Link>
+            <span className="mx-2">/</span>
+            <Link href="/stories" className="hover:underline">
+              ストーリー
+            </Link>
+            <span className="mx-2">/</span>
+            <span className="text-text-primary">{story.person.name}</span>
+          </nav>
+
+          <article className="space-y-8">
+            {/* === 記事ヘッダー（シンプル）=== */}
+            <header className="space-y-4">
+              <div className="flex flex-wrap items-center gap-3 text-sm font-noto-sans-jp">
+                <span className="px-3 py-1 rounded-full bg-muted-custom text-text-primary/70 text-xs font-bold">
+                  {story.categoryLabel}
+                </span>
+                {story.tags.map((tag) => (
+                  <span key={tag} className="text-text-primary/60 text-xs">
+                    #{tag}
+                  </span>
+                ))}
+                <span className="text-text-primary/40 text-xs ml-auto">
+                  {story.publishedAt}
+                </span>
+              </div>
+
+              <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-text-primary font-rounded-mplus leading-tight">
+                {story.title}
+              </h1>
+
+              <p className="text-base md:text-lg text-text-primary/70 font-noto-sans-jp leading-relaxed">
+                {story.excerpt}
+              </p>
+            </header>
+
+            {/* アイキャッチ */}
+            <div className="w-full rounded-xl overflow-hidden shadow-md aspect-[16/9] relative bg-muted-custom">
+              <Image
+                src={story.heroImageUrl}
+                alt={story.title}
+                fill
+                className="object-cover"
+                unoptimized
+                priority
+              />
+            </div>
+
+            {/* === 本文（パターン1: 人物・bio・SNS・ロードマップは本文中に埋め込む）=== */}
+            <div className="prose prose-lg max-w-none">
+              <div className="w-full mx-auto lg:max-w-[648px] space-y-6 font-noto-sans-jp text-text-primary leading-[200%]">
+                <p>
+                  ※ パターン1は <strong className="font-bold">/blog 完全踏襲版</strong>です。
+                  ストーリー固有の情報（人物プロフィール・bio・SNS・使ったロードマップ）は
+                  本文の見出し下に普通に書きます。
+                </p>
+
+                {/* 「インタビュー対象」が本文の見出しになる */}
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  インタビュー対象
+                </h2>
+                <p>
+                  <strong className="font-bold">{story.person.name}</strong>（{story.person.currentRole}）
+                </p>
+                {story.person.bio && <p>{story.person.bio}</p>}
+                {story.person.socialLinks && story.person.socialLinks.length > 0 && (
+                  <p>
+                    SNS:{" "}
+                    {story.person.socialLinks.map((sns, i) => (
+                      <span key={sns.label}>
+                        {i > 0 && " / "}
+                        <a
+                          href={sns.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 underline hover:text-blue-800"
+                        >
+                          {sns.label}
+                        </a>
+                      </span>
+                    ))}
+                  </p>
+                )}
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  BONOに出会うまで
+                </h2>
+                <p>
+                  営業の仕事を続けていく中で、「自分が作ったもので誰かを動かしたい」という想いが強くなっていきました。最初はオンラインスクールをいくつか試したのですが、課題が浅くて手応えが感じられず…。
+                </p>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  ロードマップを進めた3ヶ月間
+                </h2>
+                <p>
+                  BONOの「UIUX転職ロードマップ」を1日2時間ペースで進めました。特に良かったのは、各ステップで&nbsp;
+                  <strong className="font-bold">「なぜこれをやるのか」が言語化されている</strong>&nbsp;こと。
+                </p>
+
+                <blockquote className="border-l-4 border-gray-300 bg-muted-custom py-4 px-6 my-6 italic text-text-primary/80">
+                  ただ手を動かすだけじゃなくて、「次に何を学べばいいか」が常に見えていたのが大きかったです。
+                </blockquote>
+
+                {/* 「使ったコンテンツ」もただの段落 */}
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  使ったコンテンツ
+                </h2>
+                <p>
+                  📚{" "}
+                  {story.usedRoadmap ? (
+                    <Link
+                      href={story.usedRoadmap.href}
+                      className="text-blue-600 underline hover:text-blue-800"
+                    >
+                      {story.usedRoadmap.title}
+                    </Link>
+                  ) : (
+                    "UIUX転職ロードマップ"
+                  )}
+                </p>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  ポートフォリオ作成と転職活動
+                </h2>
+                <p>
+                  最終ステップで作ったポートフォリオを使って、5社にカジュアル面談を申し込みました。結果、3社から書類選考を経て面接へ進み、最終的に現在の会社に内定をもらえました。
+                </p>
+              </div>
+            </div>
+
+            {/* === シェアセクション === */}
+            <div className="mt-12 flex flex-col items-center gap-3 px-6 py-8 w-full mx-auto lg:max-w-[648px] bg-surface rounded-[36px] border border-gray-200/60">
+              <p className="text-sm text-text-primary/60 font-noto-sans-jp font-semibold">
+                よかったらシェアしてね🙋
+              </p>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <button
+                  type="button"
+                  className="bg-white border border-gray-200 flex gap-2 items-center px-4 py-2 rounded-xl shadow-sm hover:bg-gray-50 transition"
+                >
+                  <span className="font-noto-sans-jp font-semibold text-sm text-text-primary">
+                    URLをコピー
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="bg-white border border-gray-200 flex gap-2 items-center px-4 py-2 rounded-xl shadow-sm hover:bg-gray-50 transition"
+                >
+                  <span className="font-noto-sans-jp font-semibold text-sm text-text-primary">
+                    Xでシェア
+                  </span>
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </main>
+
+      {/* === 他のストーリー === */}
+      <section className="border-t border-gray-200/60 mt-12">
+        <div className="container mx-auto px-4 sm:px-6 py-12 md:py-16">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus text-center">
+              他のストーリー
+            </h2>
+            <p className="text-sm text-text-primary/60 text-center mt-2 font-noto-sans-jp">
+              こちらもよかったらどぞっ🍕
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
+              {relatedStories.map((s) => (
+                <StoryCardPatternB
+                  key={s.slug}
+                  slug={s.slug}
+                  title={s.title}
+                  heroImageUrl={s.heroImageUrl}
+                  person={s.person}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/dev/story-detail-c/page.tsx
+++ b/src/app/dev/story-detail-c/page.tsx
@@ -1,0 +1,252 @@
+/**
+ * /dev/story-detail-c — ストーリー詳細 パターン3（物語性強化版）
+ *
+ * Hero画像オーバーレイで人物名・職種・ビフォー/アフターを目立たせる。
+ * Pull Quote（引用ハイライト）で物語性を最大化。
+ * 統一感より「人生が変わったストーリー」感を優先した叩き。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { dummyStories } from "@/app/achievements/dummy-data";
+import StoryCardPatternB from "@/components/story/_patterns/StoryCardPatternB";
+
+export const metadata: Metadata = {
+  title: "ストーリー詳細 パターン3（物語性強化） (/dev/story-detail-c)",
+  robots: { index: false, follow: false },
+};
+
+export default function DevStoryDetailCPage() {
+  const story = dummyStories[0];
+  const relatedStories = dummyStories.slice(1, 3);
+
+  // ビフォー/アフター（仮：将来 person.before/after フィールドを追加検討）
+  const before = "営業職";
+  const after = "UIデザイナー";
+
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+
+      <main className="container mx-auto px-4 sm:px-6 pb-16">
+        <div className="max-w-4xl mx-auto">
+          {/* パンくず */}
+          <nav className="pt-6 pb-4 text-sm text-text-primary/60 font-noto-sans-jp">
+            <Link href="/achievements" className="hover:underline">
+              みんなの成果
+            </Link>
+            <span className="mx-2">/</span>
+            <Link href="/stories" className="hover:underline">
+              ストーリー
+            </Link>
+            <span className="mx-2">/</span>
+            <span className="text-text-primary">{story.person.name}</span>
+          </nav>
+
+          {/* === Hero（オーバーレイ強調・パターン3の目玉）=== */}
+          <div className="relative w-full rounded-[28px] overflow-hidden shadow-lg aspect-[16/9] bg-muted-custom">
+            <Image
+              src={story.heroImageUrl}
+              alt={story.title}
+              fill
+              className="object-cover"
+              unoptimized
+              priority
+            />
+
+            {/* グラデオーバーレイ */}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+
+            {/* オーバーレイテキスト */}
+            <div className="absolute inset-x-0 bottom-0 p-6 sm:p-10 text-white">
+              {/* ビフォー/アフター */}
+              <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
+                <span className="text-xs sm:text-sm font-noto-sans-jp text-white/80 px-3 py-1 rounded-full bg-white/15 backdrop-blur-sm">
+                  {before}
+                </span>
+                <span className="text-xl sm:text-2xl">▸</span>
+                <span className="text-xs sm:text-sm font-noto-sans-jp font-bold px-3 py-1 rounded-full bg-white text-text-primary">
+                  {after}
+                </span>
+              </div>
+
+              {/* 人物名 */}
+              <p className="text-lg sm:text-xl font-bold font-rounded-mplus">
+                {story.person.name}
+              </p>
+              <p className="text-xs sm:text-sm text-white/80 font-noto-sans-jp mt-1">
+                {story.person.currentRole}
+              </p>
+            </div>
+          </div>
+
+          <article className="space-y-8 mt-10">
+            {/* === 記事ヘッダー（タイトル + リード）=== */}
+            <header className="space-y-4">
+              <div className="flex flex-wrap items-center gap-3 text-sm font-noto-sans-jp">
+                <span className="px-3 py-1 rounded-full bg-muted-custom text-text-primary/70 text-xs font-bold">
+                  {story.categoryLabel}
+                </span>
+                {story.tags.map((tag) => (
+                  <span key={tag} className="text-text-primary/60 text-xs">
+                    #{tag}
+                  </span>
+                ))}
+                <span className="text-text-primary/40 text-xs ml-auto">
+                  {story.publishedAt}
+                </span>
+              </div>
+
+              <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-text-primary font-rounded-mplus leading-tight">
+                {story.title}
+              </h1>
+
+              <p className="text-base md:text-lg text-text-primary/70 font-noto-sans-jp leading-relaxed">
+                {story.excerpt}
+              </p>
+            </header>
+
+            {/* === 本文（Pull Quote で物語性強化）=== */}
+            <div className="prose prose-lg max-w-none">
+              <div className="w-full mx-auto lg:max-w-[648px] space-y-6 font-noto-sans-jp text-text-primary leading-[200%]">
+                <p>
+                  ※ パターン3は <strong className="font-bold">物語性強化版</strong>です。
+                  Heroのオーバーレイで「ビフォー/アフター」を強調し、本文中の重要な発言を
+                  Pull Quote（引用ハイライト）で抜粋表示します。
+                </p>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  BONOに出会うまで
+                </h2>
+                <p>
+                  営業の仕事を続けていく中で、「自分が作ったもので誰かを動かしたい」という想いが強くなっていきました。
+                </p>
+
+                {/* === Pull Quote: 物語性強化の目玉 === */}
+                <figure className="my-12 -mx-4 sm:mx-0">
+                  <blockquote className="relative bg-gradient-to-br from-orange-50 to-yellow-50 border-l-[6px] border-orange-400 px-6 py-8 sm:px-10 sm:py-10 rounded-r-2xl">
+                    <span className="absolute top-2 left-4 text-6xl text-orange-300/40 font-serif select-none leading-none">
+                      &ldquo;
+                    </span>
+                    <p className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus leading-relaxed relative">
+                      ただ手を動かすだけじゃなくて、「次に何を学べばいいか」が常に見えていたのが大きかったです。
+                    </p>
+                    <figcaption className="text-sm text-text-primary/60 font-noto-sans-jp mt-4">
+                      — {story.person.name}
+                    </figcaption>
+                  </blockquote>
+                </figure>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  ロードマップを進めた3ヶ月間
+                </h2>
+                <p>
+                  BONOの「UIUX転職ロードマップ」を1日2時間ペースで進めました。特に良かったのは、各ステップで&nbsp;
+                  <strong className="font-bold">「なぜこれをやるのか」が言語化されている</strong>&nbsp;こと。
+                </p>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  ポートフォリオ作成と転職活動
+                </h2>
+                <p>
+                  最終ステップで作ったポートフォリオを使って、5社にカジュアル面談を申し込みました。結果、3社から書類選考を経て面接へ進み、最終的に現在の会社に内定をもらえました。
+                </p>
+
+                {/* 2つ目の Pull Quote */}
+                <figure className="my-12 -mx-4 sm:mx-0">
+                  <blockquote className="relative bg-gradient-to-br from-orange-50 to-yellow-50 border-l-[6px] border-orange-400 px-6 py-8 sm:px-10 sm:py-10 rounded-r-2xl">
+                    <span className="absolute top-2 left-4 text-6xl text-orange-300/40 font-serif select-none leading-none">
+                      &ldquo;
+                    </span>
+                    <p className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus leading-relaxed relative">
+                      未経験でも、ちゃんと積み上げれば見える景色は変わる。
+                    </p>
+                    <figcaption className="text-sm text-text-primary/60 font-noto-sans-jp mt-4">
+                      — {story.person.name}
+                    </figcaption>
+                  </blockquote>
+                </figure>
+              </div>
+            </div>
+
+            {/* === 使ったロードマップ（小さめカード）=== */}
+            {story.usedRoadmap && (
+              <div className="w-full mx-auto lg:max-w-[648px]">
+                <Link
+                  href={story.usedRoadmap.href}
+                  className="group block bg-surface rounded-[20px] border border-gray-200/60 shadow-sm p-5 hover:shadow-md transition-shadow"
+                >
+                  <span className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+                    📚 {story.person.name} が使ったロードマップ
+                  </span>
+                  <h3 className="text-base font-bold text-text-primary font-rounded-mplus mt-1 group-hover:underline">
+                    {story.usedRoadmap.title} →
+                  </h3>
+                </Link>
+              </div>
+            )}
+
+            {/* === シェアセクション === */}
+            <div className="mt-12 flex flex-col items-center gap-3 px-6 py-8 w-full mx-auto lg:max-w-[648px] bg-surface rounded-[36px] border border-gray-200/60">
+              <p className="text-sm text-text-primary/60 font-noto-sans-jp font-semibold">
+                よかったらシェアしてね🙋
+              </p>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <button
+                  type="button"
+                  className="bg-white border border-gray-200 flex gap-2 items-center px-4 py-2 rounded-xl shadow-sm hover:bg-gray-50 transition"
+                >
+                  <span className="font-noto-sans-jp font-semibold text-sm text-text-primary">
+                    URLをコピー
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="bg-white border border-gray-200 flex gap-2 items-center px-4 py-2 rounded-xl shadow-sm hover:bg-gray-50 transition"
+                >
+                  <span className="font-noto-sans-jp font-semibold text-sm text-text-primary">
+                    Xでシェア
+                  </span>
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </main>
+
+      {/* === 他のストーリー === */}
+      <section className="border-t border-gray-200/60 mt-12">
+        <div className="container mx-auto px-4 sm:px-6 py-12 md:py-16">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus text-center">
+              他のストーリー
+            </h2>
+            <p className="text-sm text-text-primary/60 text-center mt-2 font-noto-sans-jp">
+              こちらもよかったらどぞっ🍕
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
+              {relatedStories.map((s) => (
+                <StoryCardPatternB
+                  key={s.slug}
+                  slug={s.slug}
+                  title={s.title}
+                  heroImageUrl={s.heroImageUrl}
+                  person={s.person}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/dev/story-detail-d/page.tsx
+++ b/src/app/dev/story-detail-d/page.tsx
@@ -1,0 +1,331 @@
+/**
+ * /dev/story-detail-d — ストーリー詳細 パターン4（Figma Blog 風タイポ）
+ *
+ * Figma の「PROD-Guide-Blog_2026」(node 50:725) のスタイル踏襲:
+ * - 本文 16px / line-height 1.85
+ * - H1 56px / H2 34px / H3 22px
+ * - 本文幅 max-w-[700px]
+ * - 背景 #f9f9f7、本文色 #354540
+ * - 余白たっぷり
+ *
+ * パターン2のレイアウトベース、タイポと余白のみ差し替え。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { dummyStories } from "@/app/achievements/dummy-data";
+import StoryCardPatternB from "@/components/story/_patterns/StoryCardPatternB";
+
+export const metadata: Metadata = {
+  title: "ストーリー詳細 パターン4（Figma Blog風タイポ） (/dev/story-detail-d)",
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  searchParams: Promise<{ font?: string }>;
+}
+
+export default async function DevStoryDetailDPage({ searchParams }: PageProps) {
+  const { font } = await searchParams;
+  // フォント切替: "ds" = デザインシステム（M PLUS Rounded 1c）/ default = Figma準拠（Noto Sans JP）
+  const useDesignSystem = font === "ds";
+  const titleFontClass = useDesignSystem ? "font-rounded-mplus" : "font-noto-sans-jp";
+
+  const story = dummyStories[0];
+  const relatedStories = dummyStories.slice(1, 3);
+
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク + フォント切替トグル */}
+      <div className="max-w-[700px] mx-auto px-4 sm:px-6 pt-4 flex items-center justify-between gap-4 flex-wrap">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-[#677470] hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+
+        {/* タイトルフォント切替 */}
+        <div className="inline-flex items-center gap-1 bg-gray-100 rounded-full p-1 text-xs font-noto-sans-jp">
+          <span className="px-2 text-gray-500">タイトルフォント:</span>
+          <Link
+            href="/dev/story-detail-d"
+            className={`px-3 py-1 rounded-full transition-colors ${
+              !useDesignSystem
+                ? "bg-white text-text-primary font-bold shadow-sm"
+                : "text-gray-600 hover:text-text-primary"
+            }`}
+          >
+            Figma風 (Noto Sans JP)
+          </Link>
+          <Link
+            href="/dev/story-detail-d?font=ds"
+            className={`px-3 py-1 rounded-full transition-colors ${
+              useDesignSystem
+                ? "bg-white text-text-primary font-bold shadow-sm"
+                : "text-gray-600 hover:text-text-primary"
+            }`}
+          >
+            デザインシステム (M PLUS Rounded)
+          </Link>
+        </div>
+      </div>
+
+      <main className="px-4 sm:px-6 pb-24">
+        <div className="max-w-[700px] mx-auto">
+          {/* パンくず（メタ風） */}
+          <nav className="pt-12 pb-6 text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+            <Link href="/achievements" className="hover:underline">
+              みんなの成果
+            </Link>
+            <span className="mx-2">/</span>
+            <Link href="/stories" className="hover:underline">
+              ストーリー
+            </Link>
+            <span className="mx-2">/</span>
+            <span className="text-text-primary">{story.person.name}</span>
+          </nav>
+
+          <article>
+            {/* === 記事ヘッダー === */}
+            <header className="mb-12">
+              {/* メタタグ */}
+              <div className="mb-6 flex flex-wrap items-center gap-4 text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+                <span>{story.categoryLabel}</span>
+                <span className="text-[#d4d6cc]">|</span>
+                {story.tags.map((tag) => (
+                  <span key={tag}>#{tag}</span>
+                ))}
+                <span className="text-[#d4d6cc]">|</span>
+                <span>{story.publishedAt}</span>
+              </div>
+
+              {/* H1: -8px した版（28 / 40 / 48）。フォントは切替可（Noto Sans JP ↔ M PLUS Rounded）*/}
+              <h1 className={`text-[28px] sm:text-[40px] lg:text-[48px] font-bold text-text-primary leading-[1.22] tracking-[-0.02em] ${titleFontClass}`}>
+                {story.title}
+              </h1>
+
+              {/* リード文: 16px */}
+              <p className="mt-8 text-[18px] leading-[33.3px] text-text-primary/85 font-noto-sans-jp">
+                {story.excerpt}
+              </p>
+            </header>
+
+            {/* アイキャッチ */}
+            <div className="w-full mb-16 rounded-[8px] overflow-hidden aspect-[16/9] relative bg-[#e8e9e2]">
+              <Image
+                src={story.heroImageUrl}
+                alt={story.title}
+                fill
+                className="object-cover"
+                unoptimized
+                priority
+              />
+            </div>
+
+            {/* === 人物プロフィールカード（Figma風・控えめ） === */}
+            <div className="mb-16 bg-white rounded-[12px] border border-[#e8e9e2] p-8">
+              <div className="flex items-start gap-5">
+                {story.person.profileImageUrl && (
+                  <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0 bg-[#e8e9e2]">
+                    <Image
+                      src={story.person.profileImageUrl}
+                      alt={story.person.name}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp mb-1">
+                    Interviewee
+                  </p>
+                  <h2 className="text-[22px] font-bold text-text-primary leading-[1.3] font-noto-sans-jp">
+                    {story.person.name}
+                  </h2>
+                  <p className="text-[13px] text-[#677470] mt-1 font-noto-sans-jp">
+                    {story.person.currentRole}
+                  </p>
+
+                  {story.person.bio && (
+                    <p className="text-[18px] leading-[33.3px] text-text-primary mt-4 font-noto-sans-jp">
+                      {story.person.bio}
+                    </p>
+                  )}
+
+                  {story.person.socialLinks && story.person.socialLinks.length > 0 && (
+                    <div className="flex flex-wrap gap-3 mt-5 text-[12px] font-noto-sans-jp">
+                      {story.person.socialLinks.map((sns, i) => (
+                        <span key={sns.label} className="flex items-center gap-3">
+                          {i > 0 && <span className="text-[#d4d6cc]">/</span>}
+                          <a
+                            href={sns.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-text-primary underline-offset-4 hover:underline"
+                          >
+                            {sns.label} ↗
+                          </a>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* === 本文（Figma Blog 風タイポ） === */}
+            <div className="text-text-primary font-noto-sans-jp">
+              {/* H2: 34px / 44.2px */}
+              <h2 className="text-[28px] sm:text-[34px] font-bold leading-[1.3] tracking-[-0.01em] mb-8">
+                BONOに出会うまで
+              </h2>
+
+              {/* 本文 16px / 29.6px */}
+              <div className="space-y-7 text-[18px] leading-[33.3px]">
+                <p>
+                  営業の仕事を続けていく中で、「自分が作ったもので誰かを動かしたい」という想いが強くなっていきました。最初はオンラインスクールをいくつか試したのですが、課題が浅くて手応えが感じられず…。
+                </p>
+                <p>
+                  そんなときに友人から紹介されたのが BONO でした。<strong className="font-bold">「ただ動画を見るだけのスクール」ではなく、自分でアウトプットして人にフィードバックをもらえる場</strong>という構造に惹かれて、すぐに登録しました。
+                </p>
+              </div>
+
+              <h2 className="text-[28px] sm:text-[34px] font-bold leading-[1.3] tracking-[-0.01em] mt-20 mb-8">
+                ロードマップを進めた3ヶ月間
+              </h2>
+
+              <div className="space-y-7 text-[18px] leading-[33.3px]">
+                <p>
+                  BONO の「UIUX転職ロードマップ」を 1日 2時間ペースで進めました。特に良かったのは、各ステップで「なぜこれをやるのか」が言語化されていること。
+                </p>
+              </div>
+
+              {/* 引用 */}
+              <blockquote className="my-12 border-l-[3px] border-[#d4d6cc] pl-6 py-2">
+                <p className="text-[18px] sm:text-[22px] leading-[1.7] font-bold text-text-primary">
+                  ただ手を動かすだけじゃなくて、「次に何を学べばいいか」が常に見えていたのが大きかった。
+                </p>
+                <footer className="mt-3 text-[12px] text-[#677470]">
+                  — {story.person.name}
+                </footer>
+              </blockquote>
+
+              <div className="space-y-7 text-[18px] leading-[33.3px]">
+                <p>
+                  3ヶ月の間、平日は仕事終わりの 2時間、休日は 5〜6時間。ロードマップの順番通りに進めると、自然に「次やること」が決まるので、迷う時間が圧倒的に減りました。
+                </p>
+              </div>
+
+              {/* H3 セクション */}
+              <h3 className="text-[20px] sm:text-[22px] font-bold leading-[1.4] mt-16 mb-6">
+                特に役立った 3つのレッスン
+              </h3>
+
+              <ul className="space-y-4 text-[18px] leading-[33.3px] list-disc pl-6 marker:text-[#677470]">
+                <li>UIスタイリング基礎 — ピクセル単位で詰める意識が身についた</li>
+                <li>情報設計 — 画面遷移を「ユーザーの頭の中」で考える視点</li>
+                <li>リサーチ実践 — 30人インタビューでユーザー像を立体化</li>
+              </ul>
+
+              <h2 className="text-[28px] sm:text-[34px] font-bold leading-[1.3] tracking-[-0.01em] mt-20 mb-8">
+                ポートフォリオ作成と転職活動
+              </h2>
+
+              <div className="space-y-7 text-[18px] leading-[33.3px]">
+                <p>
+                  最終ステップで作ったポートフォリオを使って、5社にカジュアル面談を申し込みました。結果、3社から書類選考を経て面接へ進み、最終的に現在の会社に内定をもらえました。
+                </p>
+              </div>
+            </div>
+
+            {/* === 使ったロードマップ（Figma風・控えめ） === */}
+            {story.usedRoadmap && (
+              <div className="mt-20">
+                <p className="text-[11px] tracking-[1.68px] uppercase text-[#677470] mb-3">
+                  Used Content
+                </p>
+                <Link
+                  href={story.usedRoadmap.href}
+                  className="group block bg-white rounded-[12px] border border-[#e8e9e2] p-6 hover:border-[#354540]/30 transition-colors"
+                >
+                  <div className="flex flex-col sm:flex-row items-start gap-5">
+                    {story.usedRoadmap.imageUrl && (
+                      <div className="relative w-full sm:w-32 aspect-[16/10] sm:aspect-square flex-shrink-0 rounded-[8px] overflow-hidden bg-[#e8e9e2]">
+                        <Image
+                          src={story.usedRoadmap.imageUrl}
+                          alt={story.usedRoadmap.title}
+                          fill
+                          className="object-cover"
+                          unoptimized
+                        />
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470]">
+                        Roadmap
+                      </p>
+                      <h3 className="text-[18px] font-bold text-text-primary mt-1 group-hover:underline">
+                        {story.usedRoadmap.title}
+                      </h3>
+                      <p className="text-[14px] text-text-primary/75 mt-2 leading-[1.7]">
+                        {story.usedRoadmap.description}
+                      </p>
+                    </div>
+                  </div>
+                </Link>
+              </div>
+            )}
+
+            {/* === シェア（Figma風・極めて控えめ） === */}
+            <div className="mt-20 pt-8 border-t border-[#e8e9e2] flex items-center justify-between">
+              <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+                Share this story
+              </p>
+              <div className="flex gap-3 text-[12px] font-noto-sans-jp">
+                <button
+                  type="button"
+                  className="text-text-primary hover:underline underline-offset-4"
+                >
+                  URLをコピー
+                </button>
+                <span className="text-[#d4d6cc]">/</span>
+                <button
+                  type="button"
+                  className="text-text-primary hover:underline underline-offset-4"
+                >
+                  Xでシェア
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </main>
+
+      {/* === 他のストーリー === */}
+      <section className="bg-white border-t border-[#e8e9e2]">
+        <div className="max-w-[1000px] mx-auto px-4 sm:px-6 py-20">
+          <p className="text-[11px] tracking-[1.68px] uppercase text-[#677470] font-noto-sans-jp mb-3 text-center">
+            More Stories
+          </p>
+          <h2 className="text-[24px] sm:text-[28px] font-bold text-text-primary text-center font-noto-sans-jp leading-tight">
+            他のストーリー
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-12">
+            {relatedStories.map((s) => (
+              <StoryCardPatternB
+                key={s.slug}
+                slug={s.slug}
+                title={s.title}
+                heroImageUrl={s.heroImageUrl}
+                person={s.person}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/dev/story-detail/page.tsx
+++ b/src/app/dev/story-detail/page.tsx
@@ -1,0 +1,284 @@
+/**
+ * /dev/story-detail — ストーリー詳細ページの叩き（パターン2）
+ *
+ * パターン2: /blog ベース + 人物プロフィールカード強化
+ * - /blog の世界観・読みやすさを踏襲
+ * - 人物プロフィールを独立ブロックで強化
+ * - 使ったロードマップを独立カードで配置
+ *
+ * 本番には出さない検証用。
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { dummyStories } from "@/app/achievements/dummy-data";
+import StoryCardPatternB from "@/components/story/_patterns/StoryCardPatternB";
+
+export const metadata: Metadata = {
+  title: "ストーリー詳細 叩き (/dev/story-detail)",
+  robots: { index: false, follow: false },
+};
+
+export default function DevStoryDetailPage() {
+  const story = dummyStories[0];
+  const relatedStories = dummyStories.slice(1, 3);
+
+  return (
+    <div className="min-h-screen">
+      {/* dev portal 戻りリンク */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-4">
+        <Link
+          href="/dev/bon-327"
+          className="text-xs text-text-primary/50 hover:underline font-noto-sans-jp"
+        >
+          ← /dev/bon-327 (BON-327 受講者まわり) に戻る
+        </Link>
+      </div>
+      <main className="container mx-auto px-4 sm:px-6 pb-16">
+        <div className="max-w-4xl mx-auto">
+          {/* パンくず */}
+          <nav className="pt-6 pb-4 text-sm text-text-primary/60 font-noto-sans-jp">
+            <Link href="/achievements" className="hover:underline">
+              みんなの成果
+            </Link>
+            <span className="mx-2">/</span>
+            <Link href="/stories" className="hover:underline">
+              ストーリー
+            </Link>
+            <span className="mx-2">/</span>
+            <span className="text-text-primary">{story.person.name}</span>
+          </nav>
+
+          {/* === 記事ヘッダー === */}
+          <article className="space-y-8">
+            <header className="space-y-4">
+              {/* カテゴリ + タグ + 公開日 */}
+              <div className="flex flex-wrap items-center gap-3 text-sm font-noto-sans-jp">
+                <span className="px-3 py-1 rounded-full bg-muted-custom text-text-primary/70 text-xs font-bold">
+                  {story.categoryLabel}
+                </span>
+                {story.tags.map((tag) => (
+                  <span key={tag} className="text-text-primary/60 text-xs">
+                    #{tag}
+                  </span>
+                ))}
+                <span className="text-text-primary/40 text-xs ml-auto">
+                  {story.publishedAt}
+                </span>
+              </div>
+
+              {/* タイトル */}
+              <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-text-primary font-rounded-mplus leading-tight">
+                {story.title}
+              </h1>
+
+              {/* リード文 */}
+              <p className="text-base md:text-lg text-text-primary/70 font-noto-sans-jp leading-relaxed">
+                {story.excerpt}
+              </p>
+            </header>
+
+            {/* アイキャッチ */}
+            <div className="w-full rounded-xl overflow-hidden shadow-md aspect-[16/9] relative bg-muted-custom">
+              <Image
+                src={story.heroImageUrl}
+                alt={story.title}
+                fill
+                className="object-cover"
+                unoptimized
+                priority
+              />
+            </div>
+
+            {/* === 人物プロフィールカード（パターン2の目玉） === */}
+            <div className="bg-surface rounded-[24px] border border-gray-200/60 shadow-sm p-6 sm:p-8">
+              <div className="flex flex-col sm:flex-row sm:items-start gap-4 sm:gap-6">
+                {/* プロフィール画像 */}
+                {story.person.profileImageUrl && (
+                  <div className="relative w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden flex-shrink-0 bg-muted-custom">
+                    <Image
+                      src={story.person.profileImageUrl}
+                      alt={story.person.name}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </div>
+                )}
+
+                {/* テキスト情報 */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp mb-1">
+                    インタビュー対象
+                  </p>
+                  <h2 className="text-xl font-bold text-text-primary font-rounded-mplus">
+                    {story.person.name}
+                  </h2>
+                  <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-0.5">
+                    {story.person.currentRole}
+                  </p>
+
+                  {story.person.bio && (
+                    <p className="text-sm text-text-primary/80 font-noto-sans-jp leading-relaxed mt-3">
+                      {story.person.bio}
+                    </p>
+                  )}
+
+                  {/* SNS リンク */}
+                  {story.person.socialLinks && story.person.socialLinks.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mt-4">
+                      {story.person.socialLinks.map((sns) => (
+                        <a
+                          key={sns.label}
+                          href={sns.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full border border-gray-300 hover:border-text-primary hover:bg-muted-custom transition-colors text-text-primary/80 font-noto-sans-jp"
+                        >
+                          {sns.label} ↗
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* === 本文（ダミー）=== */}
+            <div className="prose prose-lg max-w-none">
+              <div className="w-full mx-auto lg:max-w-[648px] space-y-6 font-noto-sans-jp text-text-primary leading-[200%]">
+                <p>
+                  ※ ここに本文が入ります。実装時は Sanity の PortableText を{" "}
+                  <code className="px-1.5 py-0.5 bg-gray-100 rounded text-sm">
+                    RichTextSection
+                  </code>{" "}
+                  で描画します。<code className="px-1.5 py-0.5 bg-gray-100 rounded text-sm">/articles</code>{" "}
+                  と同じ書式が全部使えるので、見出し・引用・画像・テーブル・コールアウト・リンクカードが配置できます。
+                </p>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  BONOに出会うまで
+                </h2>
+                <p>
+                  営業の仕事を続けていく中で、「自分が作ったもので誰かを動かしたい」という想いが強くなっていきました。最初はオンラインスクールをいくつか試したのですが、課題が浅くて手応えが感じられず…。
+                </p>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  ロードマップを進めた3ヶ月間
+                </h2>
+                <p>
+                  BONOの「UIUX転職ロードマップ」を1日2時間ペースで進めました。特に良かったのは、各ステップで&nbsp;
+                  <strong className="font-bold">「なぜこれをやるのか」が言語化されている</strong>
+                  &nbsp;こと。
+                </p>
+
+                <blockquote className="border-l-4 border-gray-300 bg-muted-custom py-4 px-6 my-6 italic text-text-primary/80">
+                  ただ手を動かすだけじゃなくて、「次に何を学べばいいか」が常に見えていたのが大きかったです。
+                </blockquote>
+
+                <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus mt-12 mb-4">
+                  ポートフォリオ作成と転職活動
+                </h2>
+                <p>
+                  最終ステップで作ったポートフォリオを使って、5社にカジュアル面談を申し込みました。結果、3社から書類選考を経て面接へ進み、最終的に現在の会社に内定をもらえました。
+                </p>
+              </div>
+            </div>
+
+            {/* === 使ったロードマップカード === */}
+            {story.usedRoadmap && (
+              <div className="w-full mx-auto lg:max-w-[648px]">
+                <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp mb-2 px-1">
+                  〇〇さんが使ったロードマップ
+                </p>
+                <Link
+                  href={story.usedRoadmap.href}
+                  className="group block bg-surface rounded-[20px] border border-gray-200/60 shadow-sm overflow-hidden hover:shadow-md transition-shadow"
+                >
+                  <div className="flex flex-col sm:flex-row gap-0">
+                    {story.usedRoadmap.imageUrl && (
+                      <div className="relative w-full sm:w-48 aspect-[16/10] sm:aspect-square flex-shrink-0 bg-muted-custom">
+                        <Image
+                          src={story.usedRoadmap.imageUrl}
+                          alt={story.usedRoadmap.title}
+                          fill
+                          className="object-cover"
+                          unoptimized
+                        />
+                      </div>
+                    )}
+                    <div className="flex-1 p-5 sm:p-6 flex flex-col justify-center">
+                      <span className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+                        📚 ロードマップ
+                      </span>
+                      <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus mt-1 group-hover:underline">
+                        {story.usedRoadmap.title}
+                      </h3>
+                      <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2 leading-relaxed">
+                        {story.usedRoadmap.description}
+                      </p>
+                      <span className="text-sm font-bold text-text-primary font-noto-sans-jp mt-3">
+                        詳しく見る →
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              </div>
+            )}
+
+            {/* === シェアセクション === */}
+            <div className="mt-12 flex flex-col items-center gap-3 px-6 py-8 w-full mx-auto lg:max-w-[648px] bg-surface rounded-[36px] border border-gray-200/60">
+              <p className="text-sm text-text-primary/60 font-noto-sans-jp font-semibold">
+                よかったらシェアしてね🙋
+              </p>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <button
+                  type="button"
+                  className="bg-white border border-gray-200 flex gap-2 items-center px-4 py-2 rounded-xl shadow-sm hover:bg-gray-50 transition"
+                >
+                  <span className="font-noto-sans-jp font-semibold text-sm text-text-primary">
+                    URLをコピー
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="bg-white border border-gray-200 flex gap-2 items-center px-4 py-2 rounded-xl shadow-sm hover:bg-gray-50 transition"
+                >
+                  <span className="font-noto-sans-jp font-semibold text-sm text-text-primary">
+                    Xでシェア
+                  </span>
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </main>
+
+      {/* === 関連ストーリー === */}
+      <section className="border-t border-gray-200/60 mt-12">
+        <div className="container mx-auto px-4 sm:px-6 py-12 md:py-16">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-xl md:text-2xl font-bold text-text-primary font-rounded-mplus text-center">
+              他のストーリー
+            </h2>
+            <p className="text-sm text-text-primary/60 text-center mt-2 font-noto-sans-jp">
+              こちらもよかったらどぞっ🍕
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
+              {relatedStories.map((s) => (
+                <StoryCardPatternB
+                  key={s.slug}
+                  slug={s.slug}
+                  title={s.title}
+                  heroImageUrl={s.heroImageUrl}
+                  person={s.person}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/outputs/page.tsx
+++ b/src/app/outputs/page.tsx
@@ -1,0 +1,79 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import OutputBannerCardItem from "@/components/output/OutputBannerCardItem";
+import { getOutputsList } from "@/lib/sanity";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "アウトプット一覧",
+  description:
+    "BONOのコンテンツを使った受講者が、実際に書いた記事を集めた場所。15分FBを受けた作品・気づきを一覧で。",
+  openGraph: {
+    title: "アウトプット一覧 | BONO",
+    description:
+      "BONOのコンテンツを使った受講者が、実際に書いた記事を集めた場所。",
+  },
+  twitter: {
+    title: "アウトプット一覧 | BONO",
+    description:
+      "BONOのコンテンツを使った受講者が、実際に書いた記事を集めた場所。",
+  },
+  alternates: { canonical: "/outputs" },
+};
+
+export default async function OutputsPage() {
+  const outputs = await getOutputsList();
+
+  return (
+    <div className="min-h-screen">
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="OUTPUTS"
+          title="アウトプット一覧"
+          description="BONOのコンテンツを使った受講者が、実際に書いた記事を集めた場所。"
+        />
+
+        <div className="mb-6">
+          <Link
+            href="/achievements"
+            className="inline-flex items-center gap-1 text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← みんなの成果 に戻る
+          </Link>
+        </div>
+
+        {outputs.length === 0 ? (
+          <p className="text-text-primary/50 text-center py-16 font-noto-sans-jp">
+            まだアウトプットが公開されていません。
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {outputs.map((output) => (
+              <OutputBannerCardItem key={output._id} output={output} />
+            ))}
+          </div>
+        )}
+
+        {/* 回遊CTA: /stories へ */}
+        <div className="mt-16 pt-12 border-t border-gray-200/60">
+          <Link
+            href="/stories"
+            className="group block bg-surface rounded-[24px] border border-gray-200/60 shadow-sm p-6 sm:p-8 hover:shadow-md hover:border-gray-300 transition-all max-w-2xl mx-auto"
+          >
+            <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+              受講者ストーリー
+            </p>
+            <h3 className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus mt-1">
+              人生を動かした受講者のインタビューも読んでみる →
+            </h3>
+            <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2">
+              転職・独立など、BONOで動き出した人たちのストーリー集。
+            </p>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -1,0 +1,194 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import PersonCard from "@/components/story/PersonCard";
+import UsedRoadmapCard from "@/components/story/UsedRoadmapCard";
+import StoryCardItem from "@/components/story/StoryCardItem";
+import RichTextSection from "@/components/article/RichTextSection";
+import {
+  getStoryBySlug,
+  getRelatedStories,
+  getAllStorySlugs,
+} from "@/lib/sanity";
+
+export const revalidate = 3600;
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  try {
+    const slugs = await getAllStorySlugs();
+    return slugs.map((slug) => ({ slug }));
+  } catch {
+    return [];
+  }
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const story = await getStoryBySlug(slug);
+
+  if (!story) {
+    return { title: "ストーリーが見つかりません" };
+  }
+
+  const ogImage = story.heroImageUrl;
+
+  return {
+    title: `${story.title} | BONO`,
+    description: story.excerpt,
+    keywords: story.tags?.join(", "),
+    openGraph: {
+      title: `${story.title} | BONO`,
+      description: story.excerpt,
+      type: "article",
+      images: ogImage ? [ogImage] : undefined,
+      publishedTime: story.publishedAt,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: story.title,
+      description: story.excerpt,
+      images: ogImage ? [ogImage] : undefined,
+    },
+    alternates: { canonical: `/stories/${slug}` },
+  };
+}
+
+function formatPublishedAt(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default async function StoryDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+  const story = await getStoryBySlug(slug);
+
+  if (!story) {
+    notFound();
+  }
+
+  const relatedStories = await getRelatedStories(story._id, 2);
+
+  return (
+    <div className="min-h-screen">
+      <main className="px-4 sm:px-6 pb-24">
+        <div className="max-w-[700px] mx-auto">
+          {/* パンくず（メタ風） */}
+          <nav className="pt-12 pb-6 text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+            <Link href="/achievements" className="hover:underline">
+              みんなの成果
+            </Link>
+            <span className="mx-2">/</span>
+            <Link href="/stories" className="hover:underline">
+              ストーリー
+            </Link>
+            <span className="mx-2">/</span>
+            <span className="text-text-primary">{story.person.name}</span>
+          </nav>
+
+          <article>
+            {/* === 記事ヘッダー === */}
+            <header className="mb-12">
+              <div className="mb-6 flex flex-wrap items-center gap-4 text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+                <span>{story.categoryLabel}</span>
+                {story.tags.length > 0 && (
+                  <>
+                    <span className="text-[#d4d6cc]">|</span>
+                    {story.tags.map((tag) => (
+                      <span key={tag}>#{tag}</span>
+                    ))}
+                  </>
+                )}
+                <span className="text-[#d4d6cc]">|</span>
+                <span>{formatPublishedAt(story.publishedAt)}</span>
+              </div>
+
+              <h1 className="text-[28px] sm:text-[40px] lg:text-[48px] font-bold text-text-primary leading-[1.22] tracking-[-0.02em] font-noto-sans-jp">
+                {story.title}
+              </h1>
+
+              <p className="mt-8 text-[18px] leading-[33.3px] text-text-primary/85 font-noto-sans-jp">
+                {story.excerpt}
+              </p>
+            </header>
+
+            {/* アイキャッチ */}
+            {story.heroImageUrl && (
+              <div className="w-full mb-16 rounded-[8px] overflow-hidden aspect-[16/9] relative bg-[#e8e9e2]">
+                <Image
+                  src={story.heroImageUrl}
+                  alt={story.title}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                  priority
+                />
+              </div>
+            )}
+
+            {/* 人物プロフィールカード */}
+            <div className="mb-16">
+              <PersonCard person={story.person} />
+            </div>
+
+            {/* 本文（PortableText・/articles と同じ書式） */}
+            <RichTextSection content={story.body} />
+
+            {/* 使ったロードマップ */}
+            {story.relatedRoadmaps && story.relatedRoadmaps.length > 0 && (
+              <div className="mt-20 space-y-6">
+                {story.relatedRoadmaps.map((roadmap) => (
+                  <UsedRoadmapCard
+                    key={roadmap._id}
+                    roadmap={roadmap}
+                    personName={story.person.name}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* シェアセクション */}
+            <div className="mt-20 pt-8 border-t border-[#e8e9e2] flex items-center justify-between">
+              <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+                Share this story
+              </p>
+              <div className="flex gap-3 text-[12px] font-noto-sans-jp">
+                <Link
+                  href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(story.title)}&url=${encodeURIComponent(`https://bono.training/stories/${slug}`)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-text-primary hover:underline underline-offset-4"
+                >
+                  Xでシェア
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </main>
+
+      {/* 他のストーリー */}
+      {relatedStories.length > 0 && (
+        <section className="bg-white border-t border-[#e8e9e2]">
+          <div className="max-w-[1000px] mx-auto px-4 sm:px-6 py-20">
+            <p className="text-[11px] tracking-[1.68px] uppercase text-[#677470] font-noto-sans-jp mb-3 text-center">
+              More Stories
+            </p>
+            <h2 className="text-[24px] sm:text-[28px] font-bold text-text-primary text-center font-rounded-mplus leading-tight">
+              他のストーリー
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-12">
+              {relatedStories.map((s) => (
+                <StoryCardItem key={s._id} story={s} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -1,0 +1,97 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import PageHeader from "@/components/common/PageHeader";
+import StoryCardItem from "@/components/story/StoryCardItem";
+import { getStoriesList } from "@/lib/sanity";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "ストーリー一覧",
+  description:
+    "BONOで学んで人生を動かした受講者たちのインタビュー記事。未経験からUIデザイナーへの転職、独立、キャリアチェンジなど。",
+  openGraph: {
+    title: "ストーリー一覧 | BONO",
+    description:
+      "BONOで学んで人生を動かした受講者たちのインタビュー記事。",
+  },
+  twitter: {
+    title: "ストーリー一覧 | BONO",
+    description:
+      "BONOで学んで人生を動かした受講者たちのインタビュー記事。",
+  },
+  alternates: { canonical: "/stories" },
+};
+
+const tagFilters = ["すべて", "未経験", "業界経験あり", "デザイン未経験"];
+
+export default async function StoriesPage() {
+  const stories = await getStoriesList();
+
+  return (
+    <div className="min-h-screen">
+      <div className="max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 min-w-0">
+        <PageHeader
+          label="STORIES"
+          title="ストーリー一覧"
+          description="BONOで学んで人生を動かした受講者たちのインタビュー記事。"
+        />
+
+        <div className="mb-6">
+          <Link
+            href="/achievements"
+            className="inline-flex items-center gap-1 text-sm text-text-primary/60 hover:underline font-noto-sans-jp"
+          >
+            ← みんなの成果 に戻る
+          </Link>
+        </div>
+
+        {/* タグフィルタ（叩き：MVP では絞り込みロジック未実装、UI のみ） */}
+        <div className="mb-8 flex flex-wrap gap-2">
+          {tagFilters.map((tag, i) => (
+            <span
+              key={tag}
+              className={`text-sm px-4 py-2 rounded-full font-noto-sans-jp ${
+                i === 0
+                  ? "bg-text-primary text-white font-bold"
+                  : "bg-muted-custom text-text-primary/70"
+              }`}
+            >
+              {i === 0 ? tag : `#${tag}`}
+            </span>
+          ))}
+        </div>
+
+        {stories.length === 0 ? (
+          <p className="text-text-primary/50 text-center py-16 font-noto-sans-jp">
+            まだストーリーが公開されていません。
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {stories.map((story) => (
+              <StoryCardItem key={story._id} story={story} />
+            ))}
+          </div>
+        )}
+
+        {/* 回遊CTA: /outputs へ */}
+        <div className="mt-16 pt-12 border-t border-gray-200/60">
+          <Link
+            href="/outputs"
+            className="group block bg-surface rounded-[24px] border border-gray-200/60 shadow-sm p-6 sm:p-8 hover:shadow-md hover:border-gray-300 transition-all max-w-2xl mx-auto"
+          >
+            <p className="text-xs font-bold text-text-primary/50 font-noto-sans-jp">
+              みんなのアウトプット
+            </p>
+            <h3 className="text-lg sm:text-xl font-bold text-text-primary font-rounded-mplus mt-1">
+              受講者が実際に書いたアウトプット記事も見てみる →
+            </h3>
+            <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2">
+              15分FBを受けた記事の一覧。「こういう使い方もできるんだ」が分かる。
+            </p>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/HeaderClient.tsx
+++ b/src/components/layout/HeaderClient.tsx
@@ -148,6 +148,33 @@ function MobileMenu() {
               </span>
             </Link>
             <Link
+              href="/achievements"
+              className="flex flex-col rounded-lg p-3 hover:bg-accent"
+            >
+              <span className="font-medium">みんなの事例</span>
+              <span className="text-sm text-muted-foreground">
+                ストーリー & アウトプット
+              </span>
+            </Link>
+            <Link
+              href="/stories"
+              className="flex flex-col rounded-lg p-3 pl-6 hover:bg-accent"
+            >
+              <span className="text-sm font-medium">ストーリー</span>
+              <span className="text-xs text-muted-foreground">
+                BONOで人生を動かした人たちのインタビュー
+              </span>
+            </Link>
+            <Link
+              href="/outputs"
+              className="flex flex-col rounded-lg p-3 pl-6 hover:bg-accent"
+            >
+              <span className="text-sm font-medium">アウトプット</span>
+              <span className="text-xs text-muted-foreground">
+                受講者の作品・記事一覧
+              </span>
+            </Link>
+            <Link
               href="/subscription"
               className="flex flex-col rounded-lg p-3 hover:bg-accent"
             >
@@ -204,6 +231,19 @@ function DesktopNavigation() {
               </ListItem>
               <ListItem href="/tools" title="その他のツール">
                 便利なデザインツール一覧
+              </ListItem>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>みんなの事例</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[500px]">
+              <ListItem href="/stories" title="ストーリー">
+                BONOで人生を動かした受講者のインタビュー
+              </ListItem>
+              <ListItem href="/outputs" title="アウトプット">
+                15分FBを受けた受講者の作品・記事
               </ListItem>
             </ul>
           </NavigationMenuContent>

--- a/src/components/layout/Sidebar/icons.tsx
+++ b/src/components/layout/Sidebar/icons.tsx
@@ -20,6 +20,7 @@ import {
   MessageQuestion,
   Messages1,
   Lamp,
+  Medal,
 } from "iconsax-react";
 
 /**
@@ -41,6 +42,7 @@ export const MenuIcons = {
   question: MessageQuestion,
   feedback: Messages1,
   knowledge: Lamp,
+  achievements: Medal,
 } as const;
 
 export type IconKey = keyof typeof MenuIcons;

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -109,6 +109,13 @@ export function Sidebar({ className, user }: SidebarProps) {
       </SidebarMenuGroup>
 
       <SidebarMenuGroup label="その他" itemGap>
+        <SidebarMenuItem
+          href="/achievements"
+          icon={<MenuIcons.achievements size={ICON_SIZE} color="#2F3037" variant="Outline" />}
+          isActive={isActive("/achievements")}
+        >
+          みんなの実績
+        </SidebarMenuItem>
         {!user && (
           <SidebarMenuItem
             href="/login"

--- a/src/components/lesson/LessonTabs.tsx
+++ b/src/components/lesson/LessonTabs.tsx
@@ -49,13 +49,13 @@ export default function LessonTabs({
         <TabsList className="w-full justify-start border-b border-gray-200 bg-transparent rounded-none h-auto p-0 mb-[32px]">
           <TabsTrigger
             value="content"
-            className="font-noto-sans-jp font-bold text-sm md:text-base px-4 md:px-6 py-2 md:py-3 rounded-none border-b-2 border-transparent !text-black data-[state=active]:border-black data-[state=active]:!text-black data-[state=active]:bg-transparent data-[state=inactive]:!text-black bg-transparent shadow-none"
+            className="font-noto-sans-jp font-bold text-sm md:text-base px-4 md:px-6 py-2 md:py-3 rounded-none border-b-2 border-transparent !text-black data-[state=active]:border-black data-[state=active]:!text-black data-[state=active]:bg-transparent data-[state=active]:!shadow-none data-[state=inactive]:!text-black bg-transparent !shadow-none"
           >
             コンテンツ
           </TabsTrigger>
           <TabsTrigger
             value="overview"
-            className="font-noto-sans-jp font-bold text-sm md:text-base px-4 md:px-6 py-2 md:py-3 rounded-none border-b-2 border-transparent !text-black data-[state=active]:border-black data-[state=active]:!text-black data-[state=active]:bg-transparent data-[state=inactive]:!text-black bg-transparent shadow-none"
+            className="font-noto-sans-jp font-bold text-sm md:text-base px-4 md:px-6 py-2 md:py-3 rounded-none border-b-2 border-transparent !text-black data-[state=active]:border-black data-[state=active]:!text-black data-[state=active]:bg-transparent data-[state=active]:!shadow-none data-[state=inactive]:!text-black bg-transparent !shadow-none"
           >
             概要・目的
           </TabsTrigger>

--- a/src/components/output/OutputBannerCard.tsx
+++ b/src/components/output/OutputBannerCard.tsx
@@ -1,0 +1,78 @@
+/**
+ * OutputBannerCard — 横長バナー型 OutputCard
+ *
+ * 参考: ユーザー指定の横長カード（aspect 2:1〜近く、2列グリッド）。
+ * サムネを大きく見せつつメタ情報を残す、Pinterest/Behanceに近いスタイル。
+ */
+
+import Image from "next/image";
+
+export interface OutputBannerCardProps {
+  title: string;
+  thumbnailUrl: string;
+  authorName: string;
+  usedContent: {
+    label: string;
+    href: string;
+  };
+  publishedAt: string;
+  externalUrl: string;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function OutputBannerCard({
+  title,
+  thumbnailUrl,
+  authorName,
+  usedContent,
+  publishedAt,
+  externalUrl,
+}: OutputBannerCardProps) {
+  return (
+    <a
+      href={externalUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block"
+    >
+      <article className="bg-surface rounded-[20px] border border-gray-200/60 overflow-hidden shadow-sm transition-all duration-200 group-hover:shadow-md group-hover:border-gray-300">
+        {/* サムネ：横長 2:1 */}
+        <div className="relative w-full aspect-[2/1] bg-muted-custom overflow-hidden">
+          <Image
+            src={thumbnailUrl}
+            alt={title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+            unoptimized
+          />
+        </div>
+
+        {/* テキスト部 */}
+        <div className="p-4 sm:p-5">
+          {/* タイトル */}
+          <h3 className="text-sm sm:text-base font-bold text-text-primary font-rounded-mplus leading-snug line-clamp-2 group-hover:underline">
+            {title}
+          </h3>
+
+          {/* メタ情報（1行・横並び・密度高め） */}
+          <div className="flex items-center gap-2 mt-2 text-xs text-text-primary/60 font-noto-sans-jp">
+            <span className="font-medium truncate">{authorName}</span>
+            <span aria-hidden className="text-text-primary/30 flex-shrink-0">•</span>
+            <span className="flex-shrink-0">{formatDate(publishedAt)}</span>
+          </div>
+
+          {/* 使ったコンテンツバッジ */}
+          <div className="mt-2.5">
+            <span className="inline-block text-xs px-2.5 py-1 rounded-full bg-muted-custom text-text-primary/70 font-noto-sans-jp">
+              {usedContent.label}
+            </span>
+          </div>
+        </div>
+      </article>
+    </a>
+  );
+}

--- a/src/components/output/OutputBannerCardItem.tsx
+++ b/src/components/output/OutputBannerCardItem.tsx
@@ -1,0 +1,104 @@
+/**
+ * OutputBannerCardItem — アウトプット一覧用カード（本番版）
+ *
+ * BON-345 確定パターン: 横長バナー型（aspect 2:1, 3列）
+ * Sanity の UserOutputSummary をそのまま受ける。
+ */
+
+import Image from "next/image";
+import type { UserOutputSummary } from "@/types/sanity";
+
+interface OutputBannerCardItemProps {
+  output: UserOutputSummary;
+}
+
+const FALLBACK_THUMB = "/placeholder-thumbnail.svg";
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/**
+ * 表示名から「頭文字」と「背景色」を作る。
+ * カッコ付き名前（例: ユウ（ビビッドピンクの人））はカッコ前から取る。
+ */
+function getInitial(name: string): string {
+  const clean = name.split(/[（(]/)[0].trim();
+  return clean.charAt(0).toUpperCase();
+}
+
+// 名前ごとに安定した色を割り当てる（パステル系）
+const AVATAR_COLORS = [
+  { bg: "#FED7AA", fg: "#9A3412" }, // orange
+  { bg: "#FECACA", fg: "#991B1B" }, // red
+  { bg: "#FDE68A", fg: "#854D0E" }, // yellow
+  { bg: "#D1FAE5", fg: "#065F46" }, // green
+  { bg: "#BFDBFE", fg: "#1E40AF" }, // blue
+  { bg: "#DDD6FE", fg: "#5B21B6" }, // purple
+  { bg: "#FBCFE8", fg: "#9D174D" }, // pink
+  { bg: "#A7F3D0", fg: "#064E3B" }, // teal
+];
+
+function getAvatarColor(name: string): { bg: string; fg: string } {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) & 0xffffffff;
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+export default function OutputBannerCardItem({ output }: OutputBannerCardItemProps) {
+  const thumb = output.articleImage || FALLBACK_THUMB;
+  const title = output.articleTitle || output.articleUrl;
+  const authorName = output.author?.displayName || "受講者";
+  const usedLabel = output.bonoContent || output.relatedLesson?.title;
+
+  return (
+    <a
+      href={output.articleUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block"
+    >
+      <article className="bg-surface rounded-[20px] border border-gray-200/60 overflow-hidden shadow-sm transition-all duration-200 group-hover:shadow-md group-hover:border-gray-300">
+        <div className="relative w-full aspect-[2/1] bg-muted-custom overflow-hidden">
+          <Image
+            src={thumb}
+            alt={title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+            unoptimized
+          />
+        </div>
+        <div className="p-4 sm:p-5">
+          <h3 className="text-sm sm:text-base font-bold text-text-primary font-rounded-mplus leading-snug line-clamp-2 group-hover:underline">
+            {title}
+          </h3>
+          <div className="flex items-center gap-2 mt-2 text-xs text-text-primary/60 font-noto-sans-jp">
+            <span
+              aria-hidden
+              className="inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold flex-shrink-0"
+              style={{
+                backgroundColor: getAvatarColor(authorName).bg,
+                color: getAvatarColor(authorName).fg,
+              }}
+            >
+              {getInitial(authorName)}
+            </span>
+            <span className="font-medium truncate">{authorName}</span>
+            <span aria-hidden className="text-text-primary/30 flex-shrink-0">•</span>
+            <span className="flex-shrink-0">{formatDate(output.submittedAt)}</span>
+          </div>
+          {usedLabel && (
+            <div className="mt-2.5">
+              <span className="inline-block text-xs px-2.5 py-1 rounded-full bg-muted-custom text-text-primary/70 font-noto-sans-jp">
+                📚 {usedLabel}
+              </span>
+            </div>
+          )}
+        </div>
+      </article>
+    </a>
+  );
+}

--- a/src/components/output/OutputCard.tsx
+++ b/src/components/output/OutputCard.tsx
@@ -1,0 +1,71 @@
+import Image from "next/image";
+
+export interface OutputCardProps {
+  title: string;
+  thumbnailUrl: string;
+  authorName: string;
+  usedContent: {
+    label: string;
+    href: string;
+  };
+  publishedAt: string;
+  externalUrl: string;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function OutputCard({
+  title,
+  thumbnailUrl,
+  authorName,
+  usedContent,
+  publishedAt,
+  externalUrl,
+}: OutputCardProps) {
+  return (
+    <a
+      href={externalUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block"
+    >
+      <article className="bg-surface rounded-[20px] sm:rounded-[24px] overflow-hidden border-4 border-white shadow-sm transition-transform duration-300 ease-out group-hover:scale-[1.02] group-hover:shadow-md">
+        {/* サムネ画像 */}
+        <div className="bg-muted-custom rounded-[16px] sm:rounded-[20px] overflow-hidden w-full aspect-[3/2] relative">
+          <Image
+            src={thumbnailUrl}
+            alt={title}
+            fill
+            className="object-cover"
+            unoptimized
+          />
+        </div>
+
+        {/* テキストコンテンツ */}
+        <div className="p-4 sm:p-5">
+          {/* タイトル */}
+          <h3 className="text-sm sm:text-base font-bold text-text-primary font-rounded-mplus leading-[1.5] line-clamp-2">
+            {title}
+          </h3>
+
+          {/* 投稿者 + 日付 */}
+          <div className="flex items-center gap-2 text-xs text-text-primary/60 font-noto-sans-jp mt-2">
+            <span>{authorName}</span>
+            <span aria-hidden>•</span>
+            <span>{formatDate(publishedAt)}</span>
+          </div>
+
+          {/* 使ったコンテンツバッジ */}
+          <div className="mt-3">
+            <span className="inline-block text-xs px-2.5 py-1 rounded-full bg-muted-custom text-text-primary/70 font-noto-sans-jp">
+              {usedContent.label}
+            </span>
+          </div>
+        </div>
+      </article>
+    </a>
+  );
+}

--- a/src/components/output/OutputListItem.tsx
+++ b/src/components/output/OutputListItem.tsx
@@ -1,0 +1,85 @@
+/**
+ * OutputListItem — 横長リスト型 OutputCard
+ *
+ * Zapier / Intercom / Substack の List view 風の横長カード。
+ * 「流し読み・件数多い」アウトプット一覧に最適化。
+ */
+
+import Image from "next/image";
+
+export interface OutputListItemProps {
+  title: string;
+  thumbnailUrl: string;
+  authorName: string;
+  usedContent: {
+    label: string;
+    href: string;
+  };
+  publishedAt: string;
+  externalUrl: string;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function OutputListItem({
+  title,
+  thumbnailUrl,
+  authorName,
+  usedContent,
+  publishedAt,
+  externalUrl,
+}: OutputListItemProps) {
+  return (
+    <a
+      href={externalUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block"
+    >
+      <article className="bg-surface rounded-[20px] border border-gray-200/60 overflow-hidden shadow-sm transition-all duration-200 group-hover:shadow-md group-hover:border-gray-300">
+        <div className="flex gap-4 sm:gap-6 p-3 sm:p-4">
+          {/* サムネ（左・固定幅） */}
+          <div className="relative w-24 sm:w-40 aspect-[4/3] flex-shrink-0 rounded-[12px] overflow-hidden bg-muted-custom">
+            <Image
+              src={thumbnailUrl}
+              alt={title}
+              fill
+              className="object-cover"
+              unoptimized
+            />
+          </div>
+
+          {/* テキスト（右・伸縮） */}
+          <div className="flex-1 min-w-0 flex flex-col justify-center gap-2">
+            {/* タイトル */}
+            <h3 className="text-sm sm:text-base font-bold text-text-primary font-rounded-mplus leading-snug line-clamp-2 group-hover:underline">
+              {title}
+            </h3>
+
+            {/* メタ情報（一行・密度高め） */}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-primary/60 font-noto-sans-jp">
+              <span className="font-medium">{authorName}</span>
+              <span aria-hidden className="text-text-primary/30">•</span>
+              <span>{formatDate(publishedAt)}</span>
+            </div>
+
+            {/* 使ったコンテンツバッジ */}
+            <div>
+              <span className="inline-block text-xs px-2.5 py-1 rounded-full bg-muted-custom text-text-primary/70 font-noto-sans-jp">
+                {usedContent.label}
+              </span>
+            </div>
+          </div>
+
+          {/* 外部リンクアイコン（PCのみ） */}
+          <div className="hidden sm:flex items-start text-text-primary/30 group-hover:text-text-primary/60 transition-colors mt-2">
+            <span aria-hidden className="text-lg">↗</span>
+          </div>
+        </div>
+      </article>
+    </a>
+  );
+}

--- a/src/components/story/PersonCard.tsx
+++ b/src/components/story/PersonCard.tsx
@@ -1,0 +1,70 @@
+/**
+ * PersonCard — ストーリー詳細ページの人物プロフィールカード
+ *
+ * BON-327 パターン4ベース（Figma Blog風タイポ）。
+ * 名前 + 職種 + bio + SNSリンク。
+ */
+
+import Image from "next/image";
+import type { StoryPerson } from "@/types/sanity";
+
+interface PersonCardProps {
+  person: StoryPerson;
+}
+
+export default function PersonCard({ person }: PersonCardProps) {
+  return (
+    <div className="bg-white rounded-[12px] border border-[#e8e9e2] p-8">
+      <div className="flex items-start gap-5">
+        {person.profileImageUrl && (
+          <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0 bg-[#e8e9e2]">
+            <Image
+              src={person.profileImageUrl}
+              alt={person.name}
+              fill
+              className="object-cover"
+              unoptimized
+            />
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp mb-1">
+            Interviewee
+          </p>
+          <h2 className="text-[22px] font-bold text-text-primary leading-[1.3] font-noto-sans-jp">
+            {person.name}
+          </h2>
+          {person.currentRole && (
+            <p className="text-[13px] text-[#677470] mt-1 font-noto-sans-jp">
+              {person.currentRole}
+            </p>
+          )}
+
+          {person.bio && (
+            <p className="text-[18px] leading-[33.3px] text-text-primary mt-4 font-noto-sans-jp">
+              {person.bio}
+            </p>
+          )}
+
+          {person.socialLinks && person.socialLinks.length > 0 && (
+            <div className="flex flex-wrap gap-3 mt-5 text-[12px] font-noto-sans-jp">
+              {person.socialLinks.map((sns, i) => (
+                <span key={`${sns.label}-${i}`} className="flex items-center gap-3">
+                  {i > 0 && <span className="text-[#d4d6cc]">/</span>}
+                  <a
+                    href={sns.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-text-primary underline-offset-4 hover:underline"
+                  >
+                    {sns.label} ↗
+                  </a>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/story/StoryCard.tsx
+++ b/src/components/story/StoryCard.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import Image from "next/image";
+
+export interface StoryCardProps {
+  slug: string;
+  title: string;
+  excerpt: string;
+  heroImageUrl: string;
+  categoryLabel: string;
+  tags: string[];
+  person: {
+    name: string;
+    profileImageUrl?: string;
+    currentRole: string;
+  };
+}
+
+export default function StoryCard({
+  slug,
+  title,
+  excerpt,
+  heroImageUrl,
+  categoryLabel,
+  tags,
+  person,
+}: StoryCardProps) {
+  return (
+    <Link href={`/stories/${slug}`} className="group block">
+      <article className="bg-surface rounded-[24px] sm:rounded-[32px] overflow-hidden border-4 border-white shadow-sm transition-transform duration-300 ease-out group-hover:scale-[1.02] group-hover:shadow-md">
+        {/* アイキャッチ画像 */}
+        <div className="bg-muted-custom rounded-[20px] sm:rounded-[28px] overflow-hidden w-full aspect-[16/9] relative">
+          <Image
+            src={heroImageUrl}
+            alt={title}
+            fill
+            className="object-cover"
+            unoptimized
+          />
+        </div>
+
+        {/* テキストコンテンツ */}
+        <div className="p-5 sm:p-6">
+          {/* カテゴリラベル */}
+          <span className="inline-block text-[10px] sm:text-xs font-bold text-text-primary/60">
+            {categoryLabel}
+          </span>
+
+          {/* タイトル */}
+          <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus leading-[1.6] mt-1 line-clamp-2">
+            {title}
+          </h3>
+
+          {/* リード文 */}
+          <p className="text-sm text-text-primary/70 font-noto-sans-jp mt-2 line-clamp-2 leading-relaxed">
+            {excerpt}
+          </p>
+
+          {/* 人物プロフィール */}
+          <div className="flex items-center gap-3 mt-4">
+            {person.profileImageUrl && (
+              <div className="relative w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-muted-custom">
+                <Image
+                  src={person.profileImageUrl}
+                  alt={person.name}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                />
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="text-sm font-bold text-text-primary leading-tight font-noto-sans-jp">
+                {person.name}
+              </p>
+              <p className="text-xs text-text-primary/60 truncate font-noto-sans-jp mt-0.5">
+                {person.currentRole}
+              </p>
+            </div>
+          </div>
+
+          {/* タグ */}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-4">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="text-xs px-2.5 py-1 rounded-full bg-muted-custom text-text-primary/70 font-noto-sans-jp"
+                >
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/src/components/story/StoryCardItem.tsx
+++ b/src/components/story/StoryCardItem.tsx
@@ -1,0 +1,99 @@
+/**
+ * StoryCardItem — 受講者ストーリー一覧用カード（本番版・現状版/全要素入り）
+ *
+ * BON-327 採用: 現状版（8要素）
+ *   1. アイキャッチ画像
+ *   2. カテゴリラベル
+ *   3. タイトル
+ *   4. リード文（excerpt）
+ *   5. プロフィール画像
+ *   6. 人物名
+ *   7. 現在の職種
+ *   8. タグ
+ *
+ * Sanity の StorySummary をそのまま受ける。
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import type { StorySummary } from "@/types/sanity";
+
+interface StoryCardItemProps {
+  story: StorySummary;
+}
+
+const FALLBACK_HERO = "/placeholder-thumbnail.svg";
+
+export default function StoryCardItem({ story }: StoryCardItemProps) {
+  const heroUrl = story.heroImageUrl || FALLBACK_HERO;
+
+  return (
+    <Link href={`/stories/${story.slug.current}`} className="group block">
+      <article className="bg-surface rounded-[24px] sm:rounded-[32px] overflow-hidden border-4 border-white shadow-sm transition-transform duration-300 ease-out group-hover:scale-[1.02] group-hover:shadow-md">
+        {/* アイキャッチ画像 */}
+        <div className="bg-muted-custom rounded-[20px] sm:rounded-[28px] overflow-hidden w-full aspect-[16/9] relative">
+          <Image
+            src={heroUrl}
+            alt={story.title}
+            fill
+            className="object-cover"
+            unoptimized
+          />
+        </div>
+
+        <div className="p-5 sm:p-6">
+          {/* カテゴリラベル */}
+          {story.categoryLabel && (
+            <span className="inline-block text-[10px] sm:text-xs font-bold text-text-primary/60">
+              {story.categoryLabel}
+            </span>
+          )}
+
+          {/* タイトル */}
+          <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus leading-[1.6] mt-1 line-clamp-2">
+            {story.title}
+          </h3>
+
+          {/* 人物プロフィール */}
+          <div className="flex items-center gap-3 mt-4">
+            {story.person.profileImageUrl && (
+              <div className="relative w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-muted-custom">
+                <Image
+                  src={story.person.profileImageUrl}
+                  alt={story.person.name}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                />
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="text-sm font-bold text-text-primary leading-tight font-noto-sans-jp">
+                {story.person.name}
+              </p>
+              {story.person.currentRole && (
+                <p className="text-xs text-text-primary/60 truncate font-noto-sans-jp mt-0.5">
+                  {story.person.currentRole}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* タグ */}
+          {story.tags && story.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-4">
+              {story.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="text-xs px-2.5 py-1 rounded-full bg-muted-custom text-text-primary/70 font-noto-sans-jp"
+                >
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/src/components/story/UsedRoadmapCard.tsx
+++ b/src/components/story/UsedRoadmapCard.tsx
@@ -1,0 +1,55 @@
+/**
+ * UsedRoadmapCard — ストーリー詳細ページで「使ったロードマップ」を表示するカード
+ *
+ * 既存 roadmap への reference を解決した StoryRelatedRoadmap を受ける。
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import type { StoryRelatedRoadmap } from "@/types/sanity";
+
+interface UsedRoadmapCardProps {
+  roadmap: StoryRelatedRoadmap;
+  personName: string;
+}
+
+export default function UsedRoadmapCard({ roadmap, personName }: UsedRoadmapCardProps) {
+  return (
+    <div>
+      <p className="text-[11px] tracking-[1.68px] uppercase text-[#677470] mb-3 font-noto-sans-jp">
+        Used Content
+      </p>
+      <Link
+        href={`/roadmap/${roadmap.slug.current}`}
+        className="group block bg-white rounded-[12px] border border-[#e8e9e2] p-6 hover:border-text-primary/30 transition-colors"
+      >
+        <div className="flex flex-col sm:flex-row items-start gap-5">
+          {roadmap.thumbnailUrl && (
+            <div className="relative w-full sm:w-32 aspect-[16/10] sm:aspect-square flex-shrink-0 rounded-[8px] overflow-hidden bg-[#e8e9e2]">
+              <Image
+                src={roadmap.thumbnailUrl}
+                alt={roadmap.title}
+                fill
+                className="object-cover"
+                unoptimized
+              />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+              {personName} さんが使ったロードマップ
+            </p>
+            <h3 className="text-[18px] font-bold text-text-primary mt-1 group-hover:underline font-noto-sans-jp">
+              {roadmap.shortTitle || roadmap.title}
+            </h3>
+            {roadmap.description && (
+              <p className="text-[14px] text-text-primary/75 mt-2 leading-[1.7] font-noto-sans-jp">
+                {roadmap.description}
+              </p>
+            )}
+          </div>
+        </div>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/story/_patterns/StoryCardPatternA.tsx
+++ b/src/components/story/_patterns/StoryCardPatternA.tsx
@@ -1,0 +1,38 @@
+/**
+ * StoryCard パターンA — 最小化（3要素）
+ * 画像 + タイトル + 人物名
+ */
+import Link from "next/link";
+import Image from "next/image";
+
+interface StoryCardPatternAProps {
+  slug: string;
+  title: string;
+  heroImageUrl: string;
+  person: { name: string };
+}
+
+export default function StoryCardPatternA({
+  slug,
+  title,
+  heroImageUrl,
+  person,
+}: StoryCardPatternAProps) {
+  return (
+    <Link href={`/stories/${slug}`} className="group block">
+      <article className="bg-surface rounded-[24px] sm:rounded-[32px] overflow-hidden border-4 border-white shadow-sm transition-transform duration-300 ease-out group-hover:scale-[1.02] group-hover:shadow-md">
+        <div className="bg-muted-custom rounded-[20px] sm:rounded-[28px] overflow-hidden w-full aspect-[16/9] relative">
+          <Image src={heroImageUrl} alt={title} fill className="object-cover" unoptimized />
+        </div>
+        <div className="p-5 sm:p-6">
+          <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus leading-[1.6] line-clamp-2">
+            {title}
+          </h3>
+          <p className="text-sm font-bold text-text-primary/70 font-noto-sans-jp mt-3">
+            {person.name}
+          </p>
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/src/components/story/_patterns/StoryCardPatternB.tsx
+++ b/src/components/story/_patterns/StoryCardPatternB.tsx
@@ -1,0 +1,43 @@
+/**
+ * StoryCard パターンB — 中庸（4要素）★推し
+ * 画像 + タイトル + 人物名 + 職種
+ */
+import Link from "next/link";
+import Image from "next/image";
+
+interface StoryCardPatternBProps {
+  slug: string;
+  title: string;
+  heroImageUrl: string;
+  person: { name: string; currentRole: string };
+}
+
+export default function StoryCardPatternB({
+  slug,
+  title,
+  heroImageUrl,
+  person,
+}: StoryCardPatternBProps) {
+  return (
+    <Link href={`/stories/${slug}`} className="group block">
+      <article className="bg-surface rounded-[24px] sm:rounded-[32px] overflow-hidden border-4 border-white shadow-sm transition-transform duration-300 ease-out group-hover:scale-[1.02] group-hover:shadow-md">
+        <div className="bg-muted-custom rounded-[20px] sm:rounded-[28px] overflow-hidden w-full aspect-[16/9] relative">
+          <Image src={heroImageUrl} alt={title} fill className="object-cover" unoptimized />
+        </div>
+        <div className="p-5 sm:p-6">
+          <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus leading-[1.6] line-clamp-2">
+            {title}
+          </h3>
+          <div className="mt-3">
+            <p className="text-sm font-bold text-text-primary font-noto-sans-jp">
+              {person.name}
+            </p>
+            <p className="text-xs text-text-primary/60 font-noto-sans-jp mt-0.5 truncate">
+              {person.currentRole}
+            </p>
+          </div>
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/src/components/story/_patterns/StoryCardPatternC.tsx
+++ b/src/components/story/_patterns/StoryCardPatternC.tsx
@@ -1,0 +1,52 @@
+/**
+ * StoryCard パターンC — タグ残す（4要素）
+ * 画像 + タイトル + 人物名 + タグ
+ */
+import Link from "next/link";
+import Image from "next/image";
+
+interface StoryCardPatternCProps {
+  slug: string;
+  title: string;
+  heroImageUrl: string;
+  tags: string[];
+  person: { name: string };
+}
+
+export default function StoryCardPatternC({
+  slug,
+  title,
+  heroImageUrl,
+  tags,
+  person,
+}: StoryCardPatternCProps) {
+  return (
+    <Link href={`/stories/${slug}`} className="group block">
+      <article className="bg-surface rounded-[24px] sm:rounded-[32px] overflow-hidden border-4 border-white shadow-sm transition-transform duration-300 ease-out group-hover:scale-[1.02] group-hover:shadow-md">
+        <div className="bg-muted-custom rounded-[20px] sm:rounded-[28px] overflow-hidden w-full aspect-[16/9] relative">
+          <Image src={heroImageUrl} alt={title} fill className="object-cover" unoptimized />
+        </div>
+        <div className="p-5 sm:p-6">
+          <h3 className="text-base sm:text-lg font-bold text-text-primary font-rounded-mplus leading-[1.6] line-clamp-2">
+            {title}
+          </h3>
+          <p className="text-sm font-bold text-text-primary/70 font-noto-sans-jp mt-3">
+            {person.name}
+          </p>
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-3">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="text-xs px-2.5 py-1 rounded-full bg-muted-custom text-text-primary/70 font-noto-sans-jp"
+                >
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -2,7 +2,7 @@ import { createClient } from "@sanity/client";
 import imageUrlBuilder from "@sanity/image-url";
 import { unstable_cache } from "next/cache";
 import { cache } from "react";
-import type { LessonWithDetails, LessonMetadata, Lesson, ArticleWithContext, Feedback, FeedbackCategory } from "@/types/sanity";
+import type { LessonWithDetails, LessonMetadata, Lesson, ArticleWithContext, Feedback, FeedbackCategory, Story, StorySummary, UserOutputSummary } from "@/types/sanity";
 import type { SanityRoadmapListItem, SanityRoadmapDetail } from "@/types/sanity-roadmap";
 import type { Guide, GuideCategory } from "@/types/guide";
 
@@ -1328,4 +1328,159 @@ export const getAllRoadmapSlugs = unstable_cache(
   },
   ["sanity:roadmaps:slugs"],
   { tags: ["roadmap"], revalidate: 3600 }
+);
+
+// ============================================
+// Story 関連のクエリ — BON-327
+// ============================================
+
+const STORY_CATEGORY_LABELS: Record<string, string> = {
+  uiux_career_change: "UIUX転職",
+};
+
+const STORY_SUMMARY_FIELDS = `
+  _id,
+  _type,
+  title,
+  slug,
+  publishedAt,
+  excerpt,
+  heroImage,
+  "heroImageUrl": heroImage.asset->url,
+  category,
+  tags,
+  person {
+    name,
+    profileImage,
+    "profileImageUrl": profileImage.asset->url,
+    currentRole,
+  }
+`;
+
+const STORY_DETAIL_FIELDS = `
+  _id,
+  _type,
+  title,
+  slug,
+  publishedAt,
+  excerpt,
+  heroImage,
+  "heroImageUrl": heroImage.asset->url,
+  category,
+  tags,
+  person {
+    name,
+    profileImage,
+    "profileImageUrl": profileImage.asset->url,
+    bio,
+    currentRole,
+    socialLinks,
+  },
+  relatedRoadmaps[]->{
+    _id,
+    title,
+    shortTitle,
+    slug,
+    description,
+    "thumbnailUrl": thumbnail.asset->url,
+  },
+  body
+`;
+
+function attachStoryCategoryLabel<T extends { category: string }>(item: T): T & { categoryLabel: string } {
+  return { ...item, categoryLabel: STORY_CATEGORY_LABELS[item.category] ?? item.category };
+}
+
+/**
+ * ストーリー一覧を取得
+ */
+export const getStoriesList = unstable_cache(
+  async (limit?: number): Promise<StorySummary[]> => {
+    const limitClause = typeof limit === "number" ? `[0...${limit}]` : "";
+    const query = `*[_type == "story" && defined(slug.current)] | order(publishedAt desc) ${limitClause} { ${STORY_SUMMARY_FIELDS} }`;
+    const results = await getClient().fetch<StorySummary[]>(query);
+    return results.map(attachStoryCategoryLabel);
+  },
+  ["sanity:stories:list"],
+  { tags: ["story"], revalidate: 3600 }
+);
+
+/**
+ * ストーリー詳細を取得
+ */
+export const getStoryBySlug = unstable_cache(
+  async (slug: string): Promise<Story | null> => {
+    const query = `*[_type == "story" && slug.current == $slug][0] { ${STORY_DETAIL_FIELDS} }`;
+    const result = await getClient().fetch<Story | null>(query, { slug });
+    return result ? attachStoryCategoryLabel(result) : null;
+  },
+  ["sanity:stories:bySlug"],
+  { tags: ["story"], revalidate: 3600 }
+);
+
+/**
+ * 関連ストーリー（同じ category、自分以外）を取得
+ */
+export const getRelatedStories = unstable_cache(
+  async (excludeId: string, limit = 2): Promise<StorySummary[]> => {
+    const query = `*[_type == "story" && _id != $excludeId && defined(slug.current)] | order(publishedAt desc) [0...${limit}] { ${STORY_SUMMARY_FIELDS} }`;
+    const results = await getClient().fetch<StorySummary[]>(query, { excludeId });
+    return results.map(attachStoryCategoryLabel);
+  },
+  ["sanity:stories:related"],
+  { tags: ["story"], revalidate: 3600 }
+);
+
+/**
+ * ストーリーの全slugを取得（generateStaticParams 用）
+ */
+export const getAllStorySlugs = unstable_cache(
+  async (): Promise<string[]> => {
+    const query = `*[_type == "story" && defined(slug.current)].slug.current`;
+    return getClient().fetch<string[]>(query);
+  },
+  ["sanity:stories:slugs"],
+  { tags: ["story"], revalidate: 3600 }
+);
+
+// ============================================
+// UserOutput 関連のクエリ — BON-345
+// ============================================
+
+// 新旧のフィールド名違いに両対応（coalesce で先に non-null を取る）
+//   旧: articleTitle / articleUrl / articleImage / articleDescription / author.displayName / relatedLesson
+//   新: ogTitle / url / ogImage / ogDescription / author.slackAccountName / lesson
+const USER_OUTPUT_FIELDS = `
+  _id,
+  _type,
+  "articleUrl": coalesce(articleUrl, url),
+  "articleTitle": coalesce(articleTitle, ogTitle),
+  "articleImage": coalesce(articleImage, ogImage),
+  "articleDescription": coalesce(articleDescription, ogDescription),
+  author {
+    userId,
+    "displayName": coalesce(displayName, slackAccountName),
+    slackAccountName,
+    email
+  },
+  bonoContent,
+  checkedItems,
+  submittedAt,
+  displayOrder,
+  "relatedLesson": coalesce(relatedLesson->{_id, title, slug}, lesson->{_id, title, slug})
+`;
+
+/**
+ * アウトプット一覧を取得
+ * BON-327 暫定: isPublished フラグを問わず、タイトル + URL が
+ * 揃っているものを公開対象とする（旧/新スキーマ両対応）。
+ */
+export const getOutputsList = unstable_cache(
+  async (limit?: number): Promise<UserOutputSummary[]> => {
+    const limitClause = typeof limit === "number" ? `[0...${limit}]` : "";
+    const query = `*[_type == "userOutput" && (defined(articleTitle) || defined(ogTitle)) && (defined(articleUrl) || defined(url))] | order(submittedAt desc) ${limitClause} { ${USER_OUTPUT_FIELDS} }`;
+    return getClient().fetch<UserOutputSummary[]>(query);
+  },
+  ["sanity:outputs:list:v3"],
+  { tags: ["userOutput"], revalidate: 3600 }
 );

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -328,3 +328,103 @@ export interface LessonMetadata {
   thumbnailUrl?: string;
   iconImageUrl?: string;
 }
+
+// ============================================================
+// Story（受講者ストーリー） — BON-327
+// ============================================================
+
+// SNS / ポートフォリオリンク
+export interface StorySocialLink {
+  label: string;
+  url: string;
+}
+
+// 人物プロフィール
+export interface StoryPerson {
+  name: string;
+  profileImage?: SanityImage;
+  profileImageUrl?: string;
+  bio?: string;
+  currentRole?: string;
+  socialLinks?: StorySocialLink[];
+}
+
+// カテゴリ enum（将来拡張可能）
+export type StoryCategory = "uiux_career_change";
+
+// 受講者ストーリー（一覧用・最小フィールド）
+export interface StorySummary {
+  _id: string;
+  _type: "story";
+  title: string;
+  slug: SanitySlug;
+  publishedAt: string;
+  excerpt: string;
+  heroImage?: SanityImage;
+  heroImageUrl?: string;
+  category: StoryCategory;
+  categoryLabel: string;
+  tags: string[];
+  person: Pick<StoryPerson, "name" | "profileImage" | "profileImageUrl" | "currentRole">;
+}
+
+// 受講者ストーリー（詳細用・全フィールド）
+export interface Story {
+  _id: string;
+  _type: "story";
+  title: string;
+  slug: SanitySlug;
+  publishedAt: string;
+  excerpt: string;
+  heroImage?: SanityImage;
+  heroImageUrl?: string;
+  person: StoryPerson;
+  category: StoryCategory;
+  categoryLabel: string;
+  tags: string[];
+  relatedRoadmaps?: StoryRelatedRoadmap[];
+  body: PortableTextBlock[];
+}
+
+// Story 内で参照するロードマップ（最小フィールド）
+export interface StoryRelatedRoadmap {
+  _id: string;
+  title: string;
+  shortTitle?: string;
+  slug: SanitySlug;
+  description?: string;
+  thumbnailUrl?: string;
+}
+
+// ============================================================
+// UserOutput（受講者アウトプット = 15分FB済み記事） — BON-345
+// ============================================================
+
+export interface UserOutputAuthor {
+  userId?: string;
+  displayName: string;
+  slackAccountName?: string;
+  email?: string;
+}
+
+export type UserOutputCheckedItem = "notice" | "before-after" | "why";
+export type UserOutputSource = "user_submission" | "admin_curated";
+
+export interface UserOutputSummary {
+  _id: string;
+  _type: "userOutput";
+  articleUrl: string;
+  articleTitle?: string;
+  articleImage?: string;
+  articleDescription?: string;
+  author?: UserOutputAuthor;
+  bonoContent?: string;
+  relatedLesson?: {
+    _id: string;
+    title: string;
+    slug: SanitySlug;
+  };
+  checkedItems?: UserOutputCheckedItem[];
+  submittedAt: string;
+  displayOrder?: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "vitest.config.ts", "src/__tests__", "supabase"]
+  "exclude": ["node_modules", "vitest.config.ts", "src/__tests__", "supabase", "scripts"]
 }


### PR DESCRIPTION
## Summary

- **/achievements** ハブ（受講者ストーリー6件 + アウトプット6件・Mixed Banner レイアウト）
- **/stories** 一覧 + **/stories/[slug]** 詳細（Figma Blog 風タイポ・本文18px/lh1.85、本文幅700px）
- **/outputs** 一覧（バナー型カード、旧/新フィールド両対応 coalesce クエリ）
- Sanity `story` スキーマ新規 + 受講者インタビュー記事23件をインポート（既存 article から Story 化）
- 既存 `userOutput` スキーマを流用（articleTitle/ogTitle、articleUrl/url の coalesce で両対応）
- グロナビ「みんなの事例 ▼ ストーリー/アウトプット」追加
- サイドナビ「みんなの実績」追加
- `/dev` 配下を `/dev/bon-327` に整理（過去の検討プロセスのアーカイブ、noindex）
- LessonTabs アクティブタブのシャドウ削除（小修正）

## 主な技術ポイント

- データ取得: `getStoriesList` / `getStoryBySlug` / `getRelatedStories` / `getOutputsList`（unstable_cache + ISR 1h）
- 詳細ページ: `RichTextSection` 流用（PortableText・カスタムブロック完備）
- バナーカード: aspect 2:1 で /stories の縦長グリッドと形状で区別
- アウトプットのイニシャルアバター: 名前ハッシュから 8色パステルから自動割当

## Test plan

- [ ] `/achievements` で「みんなの成果」H1 + サブ + ストーリー6件 + アウトプット6件が表示される
- [ ] `/stories` で 23件のストーリーカードが表示される（タグフィルタはUIのみ）
- [ ] `/stories/[slug]` の詳細ページが SSG で生成・表示される（記事本文・人物プロフィール・関連ストーリー）
- [ ] `/outputs` で公開可能なアウトプットが表示される
- [ ] グロナビ「みんなの事例 ▼」のドロップダウンが動作
- [ ] サイドナビに「みんなの実績」リンクが追加されている
- [ ] `/dev` から `/dev/bon-327` に飛んで、検討アーカイブが見える
- [ ] 既存ページ（/lessons, /articles, /blog, /guide 等）が壊れていない

## Linear
- [BON-327](https://linear.app/bono/issue/BON-327)
- [BON-345](https://linear.app/bono/issue/BON-345)（/outputs サブイシュー・本実装で同時にカバー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)