### PR TITLE
feat: Webflow Story インポート + ストーリー詳細の UI 改善 (BON-327)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f1cde369-731d-41f6-9f0b-34a16cf75bc3","pid":53432,"procStart":"Mon Jun  1 06:08:12 2026","acquiredAt":1780389427949}

--- a/scripts/diff-webflow-sanity.ts
+++ b/scripts/diff-webflow-sanity.ts
@@ -1,0 +1,180 @@
+/**
+ * Webflow の元 HTML と Sanity に投入された Portable Text を突合する。
+ *   - h2 数
+ *   - strong 数
+ *   - 画像数
+ *   - 段落数
+ *   - 文字数 (plain text)
+ *   - 「編集メモ」など気になる文言の検出
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const TARGET_SLUG = process.argv[2] || "youhadouyatedezainani-wake";
+const WEBFLOW_COLLECTION_ID = "6029d027f6cb8852cbce8c75";
+const WEBFLOW_TOKEN =
+  process.env.WEBFLOW_TOKEN ||
+  "674b54cf2429858c005eb647787f444c749bb324a1ca1615b6cf4967b4033e76";
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+async function fetchWebflowHtml(slug: string): Promise<string> {
+  let offset = 0;
+  while (true) {
+    const res = await fetch(
+      `https://api.webflow.com/v2/collections/${WEBFLOW_COLLECTION_ID}/items?limit=100&offset=${offset}`,
+      { headers: { Authorization: `Bearer ${WEBFLOW_TOKEN}` } }
+    );
+    const data = await res.json();
+    for (const item of data.items) {
+      if (item.fieldData.slug === slug) return item.fieldData["description-3"] || "";
+    }
+    offset += 100;
+    if (offset >= (data.pagination?.total ?? 0)) break;
+  }
+  return "";
+}
+
+function countTag(html: string, tag: string): number {
+  const re = new RegExp(`<${tag}\\b`, "g");
+  return (html.match(re) || []).length;
+}
+
+function htmlPlainTextLength(html: string): number {
+  return html.replace(/<[^>]+>/g, "").replace(/&[a-z]+;/g, "_").replace(/\s+/g, "").length;
+}
+
+async function main() {
+  const html = await fetchWebflowHtml(TARGET_SLUG);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const story: any = await client.fetch(
+    `*[_type == "story" && slug.current == $slug][0]{
+      _id,
+      body
+    }`,
+    { slug: TARGET_SLUG }
+  );
+
+  if (!html || !story) {
+    console.error("元データまたは投入データが見つかりません");
+    process.exit(1);
+  }
+
+  // ---- Webflow 側統計 ----
+  const wf = {
+    h2: countTag(html, "h2"),
+    h3: countTag(html, "h3"),
+    p: countTag(html, "p"),
+    strong: countTag(html, "strong"),
+    em: countTag(html, "em"),
+    a: countTag(html, "a"),
+    img: countTag(html, "img"),
+    figcaption: countTag(html, "figcaption"),
+    plainLen: htmlPlainTextLength(html),
+  };
+
+  // ---- Sanity 側統計 ----
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const blocks: any[] = story.body;
+  let sH2 = 0,
+    sH3 = 0,
+    sNormal = 0,
+    sStrong = 0,
+    sEm = 0,
+    sLink = 0,
+    sImg = 0,
+    sCap = 0,
+    sLen = 0;
+  for (const b of blocks) {
+    if (b._type === "image") {
+      sImg++;
+      if (b.caption) sCap++;
+      continue;
+    }
+    if (b._type !== "block") continue;
+    if (b.style === "h2") sH2++;
+    else if (b.style === "h3") sH3++;
+    else if (b.style === "normal") sNormal++;
+    for (const c of b.children ?? []) {
+      const marks: string[] = c.marks ?? [];
+      if (marks.includes("strong")) sStrong++;
+      if (marks.includes("em")) sEm++;
+      // markDefs の link 参照
+      for (const k of marks) {
+        if ((b.markDefs ?? []).some((d: { _key: string; _type: string }) => d._key === k && d._type === "link")) {
+          sLink++;
+        }
+      }
+      sLen += (c.text || "").replace(/\s+/g, "").length;
+    }
+  }
+
+  console.log("=== 突合結果 ===\n");
+  console.log("項目        | Webflow | Sanity | 一致");
+  console.log("------------+---------+--------+----");
+  const rows: [string, number, number][] = [
+    ["h2", wf.h2, sH2],
+    ["h3", wf.h3, sH3],
+    ["p(段落)", wf.p, sNormal],
+    ["strong", wf.strong, sStrong],
+    ["em", wf.em, sEm],
+    ["link(a)", wf.a, sLink],
+    ["img", wf.img, sImg],
+    ["caption", wf.figcaption, sCap],
+  ];
+  for (const [name, w, s] of rows) {
+    const ok = w === s ? "✓" : "✗";
+    console.log(`${name.padEnd(11)} | ${String(w).padStart(7)} | ${String(s).padStart(6)} | ${ok}`);
+  }
+  console.log(`\nテキスト文字数（空白除く）: Webflow=${wf.plainLen}  Sanity=${sLen}  差分=${wf.plainLen - sLen}`);
+
+  // ---- 気になる文言検出 ----
+  const sanityFullText = blocks
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((b: any) => b._type === "block")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .flatMap((b: any) => (b.children ?? []).map((c: { text: string }) => c.text))
+    .join("\n");
+
+  console.log("\n=== 気になる文言検出 ===");
+  const suspicious = [
+    "サムネにする画像を貼る",
+    "[🖼️",
+    "TODO",
+    "編集中",
+    "メモ",
+  ];
+  for (const word of suspicious) {
+    const hit = sanityFullText.includes(word);
+    console.log(`  ${hit ? "⚠️ 検出" : "✓ なし"}  "${word}"`);
+  }
+
+  // ---- 先頭ブロックの中身を出力 ----
+  console.log("\n=== Sanity body 先頭 8 ブロック ===");
+  for (const [i, b] of blocks.slice(0, 8).entries()) {
+    if (b._type === "image") {
+      console.log(`[${i}] image  caption="${b.caption ?? ""}"`);
+    } else {
+      const text = (b.children ?? []).map((c: { text: string; marks: string[] }) => {
+        if (c.marks?.length) return `<${c.marks.join(",")}>${c.text}</>`;
+        return c.text;
+      }).join("");
+      console.log(`[${i}] ${b.style}  ${text.slice(0, 100)}`);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/import-webflow-story.ts
+++ b/scripts/import-webflow-story.ts
@@ -1,0 +1,520 @@
+/**
+ * Webflow の 1記事 (slug 指定) を Sanity の story として投入する。
+ * - 本文 (description-3 / HTML) → Portable Text に変換
+ * - 本文中の <img> と heroImage は Sanity Assets にアップロード
+ *
+ * 実行:
+ *   npx tsx scripts/import-webflow-story.ts --slug=youhadouyatedezainani-wake --dry-run
+ *   npx tsx scripts/import-webflow-story.ts --slug=youhadouyatedezainani-wake
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import crypto from "crypto";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const REPLACE = args.includes("--replace"); // 既存 story を上書き更新
+const slugArg = args.find((a) => a.startsWith("--slug="));
+const TARGET_SLUG = slugArg ? slugArg.split("=")[1] : "youhadouyatedezainani-wake";
+const personArg = args.find((a) => a.startsWith("--person="));
+const PERSON_OVERRIDE = personArg ? personArg.split("=")[1] : null;
+
+const WEBFLOW_COLLECTION_ID = "6029d027f6cb8852cbce8c75";
+const WEBFLOW_TOKEN =
+  process.env.WEBFLOW_TOKEN ||
+  "674b54cf2429858c005eb647787f444c749bb324a1ca1615b6cf4967b4033e76";
+
+const writeToken = process.env.SANITY_WRITE_TOKEN;
+if (!writeToken && !DRY_RUN) {
+  console.error("⚠️  SANITY_WRITE_TOKEN が必要です");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: writeToken,
+  useCdn: false,
+});
+
+// ============================================
+// 型
+// ============================================
+
+type SanityImageRef = {
+  _type: "image";
+  asset: { _type: "reference"; _ref: string };
+};
+
+type PtSpan = { _type: "span"; _key: string; marks: string[]; text: string };
+type PtMarkDef = { _key: string; _type: string; href?: string };
+type PtBlock = {
+  _type: "block";
+  _key: string;
+  style: string;
+  markDefs: PtMarkDef[];
+  children: PtSpan[];
+  level?: number;
+  listItem?: string;
+};
+type PtImage = {
+  _type: "image";
+  _key: string;
+  asset: { _type: "reference"; _ref: string };
+  alt?: string;
+  caption?: string;
+};
+
+type PtNode = PtBlock | PtImage;
+
+// ============================================
+// ユーティリティ
+// ============================================
+
+function randKey(len = 12): string {
+  return crypto.randomBytes(len / 2).toString("hex");
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+async function uploadImageFromUrl(url: string): Promise<SanityImageRef | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn(`  ⚠️  画像取得失敗: ${res.status} ${url}`);
+      return null;
+    }
+    const buffer = Buffer.from(await res.arrayBuffer());
+    const cleanUrl = url.split("?")[0];
+    const ext = cleanUrl.split(".").pop()?.toLowerCase() || "jpg";
+    const asset = await client.assets.upload("image", buffer, {
+      filename: `story-${randKey()}.${ext}`,
+    });
+    return {
+      _type: "image",
+      asset: { _type: "reference", _ref: asset._id },
+    };
+  } catch (e) {
+    console.warn(`  ⚠️  画像アップロード失敗: ${e}`);
+    return null;
+  }
+}
+
+// ============================================
+// HTML → Portable Text 変換
+// ============================================
+
+/**
+ * インライン HTML 文字列を span[] + markDefs[] に変換する。
+ * 対応タグ: <strong>, <em>, <a href="...">
+ */
+function parseInlineHtml(html: string): { spans: PtSpan[]; markDefs: PtMarkDef[] } {
+  const markDefs: PtMarkDef[] = [];
+  const spans: PtSpan[] = [];
+
+  // タグを境界として走査
+  type Marker = { kind: "open" | "close"; tag: string; href?: string; pos: number; raw: string };
+  const markers: Marker[] = [];
+  const tagRe = /<(\/?)(\w+)([^>]*)>/g;
+  let mm: RegExpExecArray | null;
+  while ((mm = tagRe.exec(html)) !== null) {
+    const closing = mm[1] === "/";
+    const tag = mm[2].toLowerCase();
+    const attrs = mm[3];
+    if (!["strong", "em", "b", "i", "a"].includes(tag)) continue;
+    let href: string | undefined;
+    if (!closing && tag === "a") {
+      const hrefMatch = attrs.match(/href="([^"]+)"/);
+      if (hrefMatch) href = hrefMatch[1];
+    }
+    markers.push({ kind: closing ? "close" : "open", tag, href, pos: mm.index, raw: mm[0] });
+  }
+
+  // marker を順に処理して活性マークを管理
+  const active: string[] = []; // span に付ける marks（"strong"/"em" or markDef key）
+  let cursor = 0;
+
+  const pushText = (raw: string) => {
+    const text = decodeEntities(raw).replace(/[​-‍﻿]/g, "");
+    if (!text) return;
+    spans.push({
+      _type: "span",
+      _key: randKey(),
+      marks: [...active],
+      text,
+    });
+  };
+
+  for (const m of markers) {
+    if (m.pos > cursor) {
+      pushText(html.slice(cursor, m.pos));
+    }
+    if (m.kind === "open") {
+      if (m.tag === "strong" || m.tag === "b") active.push("strong");
+      else if (m.tag === "em" || m.tag === "i") active.push("em");
+      else if (m.tag === "a" && m.href) {
+        const key = randKey();
+        markDefs.push({ _key: key, _type: "link", href: m.href });
+        active.push(key);
+      }
+    } else {
+      // close: 直近の対応する mark を取り除く
+      const expected =
+        m.tag === "strong" || m.tag === "b"
+          ? "strong"
+          : m.tag === "em" || m.tag === "i"
+            ? "em"
+            : null;
+      if (expected) {
+        const idx = active.lastIndexOf(expected);
+        if (idx >= 0) active.splice(idx, 1);
+      } else if (m.tag === "a") {
+        // markDef の key を最後尾から取り除く（最後に push した markDef key を想定）
+        for (let i = active.length - 1; i >= 0; i--) {
+          if (markDefs.some((d) => d._key === active[i])) {
+            active.splice(i, 1);
+            break;
+          }
+        }
+      }
+    }
+    cursor = m.pos + m.raw.length;
+  }
+  if (cursor < html.length) pushText(html.slice(cursor));
+
+  // 隣り合う同じマークの span を結合
+  const merged: PtSpan[] = [];
+  for (const s of spans) {
+    const last = merged[merged.length - 1];
+    if (last && JSON.stringify(last.marks) === JSON.stringify(s.marks)) {
+      last.text += s.text;
+    } else {
+      merged.push(s);
+    }
+  }
+  return { spans: merged.filter((s) => s.text.length > 0), markDefs };
+}
+
+function inlineHtmlToBlock(html: string, style: string): PtBlock | null {
+  // 中身のテキストが空（&zwj; や空白のみ）ならスキップ
+  const stripped = html.replace(/<[^>]+>/g, "").replace(/[\s​-‍﻿‍]/g, "");
+  if (!stripped) return null;
+  const { spans, markDefs } = parseInlineHtml(html);
+  if (spans.length === 0) return null;
+  return {
+    _type: "block",
+    _key: randKey(),
+    style,
+    markDefs,
+    children: spans,
+  };
+}
+
+/**
+ * Webflow の HTML (description-3) を Portable Text 配列に変換する。
+ * <figure><div><img></div><figcaption>...</figcaption></figure> を image ブロックに、
+ * <p>, <h2>, <h3> を block に変換する。
+ */
+async function htmlToPortableText(html: string, dryRun: boolean): Promise<PtNode[]> {
+  const out: PtNode[] = [];
+
+  // figure 単位で本文を分割
+  const figureRe = /<figure[^>]*>[\s\S]*?<\/figure>/g;
+  let lastIndex = 0;
+  const figureMatches: { match: RegExpExecArray; full: string }[] = [];
+  let fm: RegExpExecArray | null;
+  while ((fm = figureRe.exec(html)) !== null) {
+    figureMatches.push({ match: fm, full: fm[0] });
+  }
+
+  const processTextSegment = (segment: string) => {
+    // <p>, <h2>, <h3>, <h4> ブロック単位で抽出
+    const blockRe = /<(p|h[1-6])(?:\s[^>]*)?>([\s\S]*?)<\/\1>/g;
+    let bm: RegExpExecArray | null;
+    while ((bm = blockRe.exec(segment)) !== null) {
+      const tag = bm[1].toLowerCase();
+      const inner = bm[2];
+      // Webflow の編集中メモ「[🖼️ サムネにする画像を貼る]」等をスキップ
+      const plain = decodeEntities(inner.replace(/<[^>]+>/g, "")).trim();
+      if (/^\[[🖼📷📌🚧✏️].*\]$/.test(plain) || /サムネにする画像を貼る/.test(plain)) {
+        continue;
+      }
+      const style = tag === "p" ? "normal" : `h${Math.min(parseInt(tag.slice(1)), 4)}`;
+      const block = inlineHtmlToBlock(inner, style);
+      if (block) out.push(block);
+    }
+  };
+
+  for (const f of figureMatches) {
+    // figure より前のテキスト
+    if (f.match.index > lastIndex) {
+      processTextSegment(html.slice(lastIndex, f.match.index));
+    }
+    // figure の中身（画像 + caption）
+    const imgMatch = f.full.match(/<img[^>]*src="([^"]+)"[^>]*>/);
+    const captionRawMatch = f.full.match(/<figcaption[^>]*>([\s\S]*?)<\/figcaption>/);
+    const captionRaw = captionRawMatch ? captionRawMatch[1] : "";
+    const captionPlain = decodeEntities(captionRaw.replace(/<[^>]+>/g, "")).trim();
+    const captionHasLink = /<a\s[^>]*href=/i.test(captionRaw);
+    const altMatch = f.full.match(/<img[^>]*alt="([^"]*)"/);
+    if (imgMatch) {
+      const src = imgMatch[1];
+      const alt = altMatch ? altMatch[1] : undefined;
+      const altClean = alt && alt !== "__wf_reserved_inherit" ? alt : captionPlain || undefined;
+
+      console.log(`  📷 画像: ${src.slice(0, 80)}...`);
+      if (dryRun) {
+        out.push({
+          _type: "image",
+          _key: randKey(),
+          asset: { _type: "reference", _ref: `dry-${randKey()}` },
+          alt: altClean,
+          caption: captionPlain || undefined,
+        });
+      } else {
+        const uploaded = await uploadImageFromUrl(src);
+        if (uploaded) {
+          out.push({
+            _type: "image",
+            _key: randKey(),
+            asset: uploaded.asset,
+            alt: altClean,
+            caption: captionPlain || undefined,
+          });
+        }
+      }
+      // figcaption に <a> がある場合、その情報を保持するため image ブロックの直後に
+      // インラインリンク含む段落を追加する
+      if (captionHasLink) {
+        const linkBlock = inlineHtmlToBlock(captionRaw, "normal");
+        if (linkBlock) out.push(linkBlock);
+      }
+    }
+    lastIndex = f.match.index + f.full.length;
+  }
+  // 残り
+  if (lastIndex < html.length) {
+    processTextSegment(html.slice(lastIndex));
+  }
+  return out;
+}
+
+// ============================================
+// メイン
+// ============================================
+
+async function fetchWebflowItem(slug: string) {
+  let offset = 0;
+  const limit = 100;
+  while (true) {
+    const res = await fetch(
+      `https://api.webflow.com/v2/collections/${WEBFLOW_COLLECTION_ID}/items?limit=${limit}&offset=${offset}`,
+      { headers: { Authorization: `Bearer ${WEBFLOW_TOKEN}` } }
+    );
+    const data: {
+      items: Array<{
+        id: string;
+        lastPublished?: string | null;
+        createdOn?: string;
+        fieldData: Record<string, unknown> & { slug?: string };
+      }>;
+      pagination?: { total?: number };
+    } = await res.json();
+    for (const item of data.items) {
+      if (item.fieldData.slug === slug) return item;
+    }
+    offset += limit;
+    if (offset >= (data.pagination?.total ?? 0)) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return null;
+}
+
+function extractPersonName(title: string, slug: string, bodyHtml: string): string {
+  // 1) タイトルに「〜さん/くん」があれば最優先
+  const fromTitle = title.match(/([ぁ-んァ-ヶー一-龯a-zA-Z0-9]+?)(さん|くん)/);
+  if (fromTitle) return `${fromTitle[1]}${fromTitle[2]}`;
+
+  // 2) 本文 HTML 内の <strong>〜さん/くん</strong> を探す（インタビュー記事は話者が <strong> で囲まれる）
+  const strongRe = /<strong[^>]*>([^<]+?)(さん|くん)<\/strong>/g;
+  const speakers: Record<string, number> = {};
+  let m: RegExpExecArray | null;
+  while ((m = strongRe.exec(bodyHtml)) !== null) {
+    const name = `${m[1]}${m[2]}`;
+    speakers[name] = (speakers[name] || 0) + 1;
+  }
+  // カイクン以外で最頻出のもの = インタビュイー
+  const intervieweeEntry = Object.entries(speakers)
+    .filter(([name]) => !/カイクン|kaikun|カイ君/i.test(name))
+    .sort((a, b) => b[1] - a[1])[0];
+  if (intervieweeEntry) return intervieweeEntry[0];
+
+  // 3) slug 末尾フォールバック
+  const slugClean = slug
+    .replace(/-?(copy|0?\d+)$/i, "")
+    .replace(
+      /^(youhadouyatedezainani|youhadouyatedesigner|howareyoubecomethedesigner|howtobedesigner)/i,
+      ""
+    );
+  const sm = slugClean.match(/-?([a-z]+)$/i);
+  if (sm && sm[1].length >= 2) {
+    return sm[1].charAt(0).toUpperCase() + sm[1].slice(1) + "さん";
+  }
+  return "BONO受講者";
+}
+
+function guessTag(title: string): string {
+  if (title.includes("未経験")) return "未経験";
+  return "業界経験あり";
+}
+
+async function main() {
+  console.log(`\n${DRY_RUN ? "🧪 DRY RUN" : "🚀 PRODUCTION"} - slug=${TARGET_SLUG}\n`);
+
+  // 既存 story 確認
+  const exists = (await client.fetch(
+    `*[_type == "story" && slug.current == $slug][0]{ _id }`,
+    { slug: TARGET_SLUG }
+  )) as { _id: string } | null;
+  if (exists && !DRY_RUN && !REPLACE) {
+    console.error(`⛔ 同じ slug の story がすでに存在します: ${exists._id}`);
+    console.error("   既存を上書きする場合は --replace を付けてください");
+    process.exit(1);
+  }
+  if (exists && REPLACE) {
+    console.log(`ℹ️  既存 story (${exists._id}) を上書きします\n`);
+  }
+
+  // Webflow Item 取得
+  console.log("Webflow Item を検索中...");
+  const item = await fetchWebflowItem(TARGET_SLUG);
+  if (!item) {
+    console.error("⛔ Webflow Item が見つかりません");
+    process.exit(1);
+  }
+
+  const fd = item.fieldData;
+  const title = (fd.videotitle as string) || (fd.name as string) || "";
+  const excerpt = ((fd["search-description"] as string) || "").slice(0, 160);
+  const html = (fd["description-3"] as string) || "";
+  const publishedAt =
+    (item.lastPublished as string | undefined) ||
+    (item.createdOn as string | undefined) ||
+    new Date().toISOString();
+  const thumbObj = fd["video-thumbnail"] as { url?: string } | null;
+  const thumbnailUrl = thumbObj?.url;
+
+  console.log(`title: ${title}`);
+  console.log(`publishedAt: ${publishedAt}`);
+  console.log(`html length: ${html.length}`);
+  console.log(`thumbnail: ${thumbnailUrl || "(なし)"}`);
+  console.log();
+
+  // 本文 HTML → Portable Text
+  console.log("HTML → Portable Text 変換中...");
+  const body = await htmlToPortableText(html, DRY_RUN);
+  const imageCount = body.filter((b) => b._type === "image").length;
+  const blockCount = body.filter((b) => b._type === "block").length;
+  console.log(`  ブロック数: ${blockCount}, 画像数: ${imageCount}\n`);
+
+  // heroImage アップロード
+  let heroImage: SanityImageRef | null = null;
+  if (thumbnailUrl) {
+    if (DRY_RUN) {
+      console.log("📷 heroImage: (dry-run スキップ)");
+      heroImage = { _type: "image", asset: { _type: "reference", _ref: "dry-hero" } };
+    } else {
+      console.log("📷 heroImage アップロード中...");
+      heroImage = await uploadImageFromUrl(thumbnailUrl);
+      console.log(`  asset: ${heroImage?.asset._ref ?? "失敗"}`);
+    }
+  }
+
+  const personName = PERSON_OVERRIDE || extractPersonName(title, TARGET_SLUG, html);
+  const tag = guessTag(title);
+
+  console.log(`\n--- メタデータ ---`);
+  console.log(`person.name: ${personName}`);
+  console.log(`tag: #${tag}`);
+  console.log(`excerpt: ${excerpt}`);
+
+  const storyDoc = {
+    _type: "story",
+    title,
+    slug: { _type: "slug", current: TARGET_SLUG },
+    publishedAt,
+    excerpt,
+    heroImage,
+    person: { name: personName },
+    category: "uiux_career_change",
+    tags: [tag],
+    body,
+  };
+
+  if (DRY_RUN) {
+    console.log("\n--- Story doc プレビュー（body は省略） ---");
+    console.log(
+      JSON.stringify(
+        {
+          ...storyDoc,
+          body: `[${blockCount} blocks + ${imageCount} images]`,
+        },
+        null,
+        2
+      )
+    );
+    console.log("\n--- body block types in order ---");
+    body.forEach((b, i) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const bb = b as any;
+      if (b._type === "image") {
+        console.log(`[${i}] image  alt="${bb.alt ?? ""}"  caption="${bb.caption ?? ""}"`);
+      } else {
+        const preview = (bb.children ?? []).map((c: { text?: string }) => c.text || "").join("").slice(0, 40);
+        console.log(`[${i}] ${bb.style}  "${preview}"`);
+      }
+    });
+    return;
+  }
+
+  console.log("\n💾 Sanity に投入中...");
+  if (exists && REPLACE) {
+    // 既存ドキュメントを置き換え（_id を保持して、heroImage と body を更新）
+    const patched = await client
+      .patch(exists._id)
+      .set({
+        title: storyDoc.title,
+        publishedAt: storyDoc.publishedAt,
+        excerpt: storyDoc.excerpt,
+        heroImage: storyDoc.heroImage,
+        person: storyDoc.person,
+        category: storyDoc.category,
+        tags: storyDoc.tags,
+        body: storyDoc.body,
+      })
+      .commit();
+    console.log(`\n✅ 更新完了: _id=${patched._id}`);
+  } else {
+    const created = await client.create(storyDoc);
+    console.log(`\n✅ 投入完了: _id=${created._id}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/inspect-webflow-article.ts
+++ b/scripts/inspect-webflow-article.ts
@@ -1,0 +1,132 @@
+/**
+ * 指定 slug の記事が Sanity と Webflow にあるかを調査する。
+ *   - Sanity 側: article / story の存在
+ *   - Webflow 側: Item の中身（本文含む）
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const TARGET_SLUG = "youhadouyatedezainani-wake";
+const WEBFLOW_COLLECTION_ID = "6029d027f6cb8852cbce8c75";
+const WEBFLOW_TOKEN =
+  process.env.WEBFLOW_TOKEN ||
+  "674b54cf2429858c005eb647787f444c749bb324a1ca1615b6cf4967b4033e76";
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+async function main() {
+  // ---- 1) Sanity の article 側を確認 ----
+  const article = await client.fetch(
+    `*[_type == "article" && slug.current == $slug][0]{
+      _id, title, slug, publishedAt, excerpt, tags, author, thumbnailUrl,
+      "hasThumbnail": defined(thumbnail.asset._ref),
+      "contentBlocks": count(content),
+      "questTitle": *[_type == "quest" && ^._id in articles[]._ref][0].title,
+      "lessonSlug": *[_type == "quest" && ^._id in articles[]._ref][0].lesson->slug.current
+    }`,
+    { slug: TARGET_SLUG }
+  );
+  console.log("=== Sanity article ===");
+  console.log(JSON.stringify(article, null, 2));
+
+  // ---- 2) Sanity の story 側を確認 ----
+  const story = await client.fetch(
+    `*[_type == "story" && slug.current == $slug][0]{
+      _id, title, slug, publishedAt, "bodyBlocks": count(body)
+    }`,
+    { slug: TARGET_SLUG }
+  );
+  console.log("\n=== Sanity story ===");
+  console.log(JSON.stringify(story, null, 2));
+
+  // ---- 3) Webflow API から記事 Item を検索 ----
+  console.log("\n=== Webflow Item 検索中... ===");
+  let offset = 0;
+  const limit = 100;
+  let found:
+    | {
+        id: string;
+        lastPublished?: string | null;
+        createdOn?: string;
+        fieldData: Record<string, unknown>;
+      }
+    | null = null;
+
+  while (true) {
+    const res = await fetch(
+      `https://api.webflow.com/v2/collections/${WEBFLOW_COLLECTION_ID}/items?limit=${limit}&offset=${offset}`,
+      { headers: { Authorization: `Bearer ${WEBFLOW_TOKEN}` } }
+    );
+    if (!res.ok) {
+      console.error(`Webflow API error: ${res.status}`);
+      break;
+    }
+    const data: {
+      items: Array<{
+        id: string;
+        lastPublished?: string | null;
+        createdOn?: string;
+        fieldData: { slug?: string } & Record<string, unknown>;
+      }>;
+      pagination?: { total?: number };
+    } = await res.json();
+
+    for (const item of data.items) {
+      if (item.fieldData?.slug === TARGET_SLUG) {
+        found = item;
+        break;
+      }
+    }
+    if (found) break;
+    offset += limit;
+    if (offset >= (data.pagination?.total ?? 0)) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  if (!found) {
+    console.log("該当する Webflow Item が見つかりませんでした");
+    return;
+  }
+
+  // ---- 4) Webflow Item の構造表示（フィールド名と各値の文字数だけ）----
+  console.log("\n=== Webflow Item (要約) ===");
+  console.log(`id: ${found.id}`);
+  console.log(`lastPublished: ${found.lastPublished}`);
+  console.log(`createdOn: ${found.createdOn}`);
+  console.log(`\nfieldData keys:`);
+  for (const [k, v] of Object.entries(found.fieldData)) {
+    if (typeof v === "string") {
+      console.log(`  ${k}: string(${v.length})  preview="${v.slice(0, 80).replace(/\n/g, " ")}"`);
+    } else if (typeof v === "object" && v !== null) {
+      console.log(`  ${k}: object → ${JSON.stringify(v).slice(0, 100)}`);
+    } else {
+      console.log(`  ${k}: ${typeof v} = ${v}`);
+    }
+  }
+
+  // ---- 5) 本文っぽいフィールドの本体を出力 ----
+  console.log("\n=== Webflow Item 本文フィールド ===");
+  const candidates = ["post-body", "rich-text", "body", "content", "post-content"];
+  for (const key of candidates) {
+    const v = (found.fieldData as Record<string, unknown>)[key];
+    if (v) {
+      console.log(`\n--- ${key} ---`);
+      console.log(typeof v === "string" ? v.slice(0, 500) : JSON.stringify(v).slice(0, 500));
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/inspect-webflow-body.ts
+++ b/scripts/inspect-webflow-body.ts
@@ -1,0 +1,79 @@
+/**
+ * Webflow Item の description-3 / scene-3 を取得して中身を確認。
+ * 特に <img> がどう含まれているか、タグの種類を一覧化する。
+ */
+
+const TARGET_SLUG = "youhadouyatedezainani-wake";
+const WEBFLOW_COLLECTION_ID = "6029d027f6cb8852cbce8c75";
+const WEBFLOW_TOKEN =
+  process.env.WEBFLOW_TOKEN ||
+  "674b54cf2429858c005eb647787f444c749bb324a1ca1615b6cf4967b4033e76";
+
+async function main() {
+  let offset = 0;
+  const limit = 100;
+  let body: string | null = null;
+
+  while (true) {
+    const res = await fetch(
+      `https://api.webflow.com/v2/collections/${WEBFLOW_COLLECTION_ID}/items?limit=${limit}&offset=${offset}`,
+      { headers: { Authorization: `Bearer ${WEBFLOW_TOKEN}` } }
+    );
+    const data: {
+      items: Array<{
+        fieldData: { slug?: string } & Record<string, unknown>;
+      }>;
+      pagination?: { total?: number };
+    } = await res.json();
+    for (const item of data.items) {
+      if (item.fieldData?.slug === TARGET_SLUG) {
+        body = (item.fieldData["description-3"] as string) || null;
+        break;
+      }
+    }
+    if (body) break;
+    offset += limit;
+    if (offset >= (data.pagination?.total ?? 0)) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  if (!body) {
+    console.log("not found");
+    return;
+  }
+
+  console.log(`description-3 length: ${body.length}\n`);
+
+  // タグの種類を集計
+  const tagCounts: Record<string, number> = {};
+  const tagRegex = /<(\w+)[^>]*>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRegex.exec(body)) !== null) {
+    const tag = m[1].toLowerCase();
+    tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+  }
+  console.log("タグ別出現回数:");
+  for (const [tag, count] of Object.entries(tagCounts).sort((a, b) => b[1] - a[1])) {
+    console.log(`  <${tag}>: ${count}`);
+  }
+
+  // <img> 抽出
+  const imgs = body.match(/<img[^>]*>/g) ?? [];
+  console.log(`\n<img> タグ数: ${imgs.length}`);
+  imgs.slice(0, 10).forEach((tag, i) => {
+    console.log(`\n[${i + 1}] ${tag}`);
+  });
+
+  // 先頭 1500 文字
+  console.log("\n=== 本文 head ===");
+  console.log(body.slice(0, 1500));
+
+  // 末尾 500 文字
+  console.log("\n=== 本文 tail ===");
+  console.log(body.slice(-500));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/update-stories-body.ts
+++ b/scripts/update-stories-body.ts
@@ -1,0 +1,317 @@
+/**
+ * 既存 story 23件に対して、Webflow の description-3 (HTML本文) を取得し、
+ * 簡易的に PortableText に変換して story.body に入れる。
+ *
+ * HTML 変換は簡易版:
+ *   - <p>, <h2>, <h3>, <h4>, <blockquote> → 対応する PortableText block
+ *   - <ol><li>, <ul><li> → list (number / bullet)
+ *   - <strong>, <em>, <a href="..."> → marks
+ *   - <img src="..."> → image block (外部URLそのまま、Sanity asset 化はしない)
+ *   - <br> → 改行（block 内の改行は無視、別 block にする）
+ *
+ * 実行: npx tsx scripts/update-stories-body.ts [--dry-run]
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+import { randomUUID } from "crypto";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const WEBFLOW_COLLECTION_ID = "6029d027f6cb8852cbce8c75";
+const WEBFLOW_TOKEN =
+  process.env.WEBFLOW_TOKEN ||
+  "674b54cf2429858c005eb647787f444c749bb324a1ca1615b6cf4967b4033e76";
+
+const writeToken = process.env.SANITY_WRITE_TOKEN;
+if (!writeToken && !DRY_RUN) {
+  console.error("⚠️  SANITY_WRITE_TOKEN が必要です");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: writeToken,
+  useCdn: false,
+});
+
+const key = () => randomUUID().replace(/-/g, "").slice(0, 12);
+
+// =======================================================
+// 簡易 HTML → PortableText 変換
+// =======================================================
+
+interface PTSpan {
+  _type: "span";
+  _key: string;
+  text: string;
+  marks: string[];
+}
+
+interface PTBlock {
+  _type: "block";
+  _key: string;
+  style: "normal" | "h2" | "h3" | "h4" | "blockquote";
+  listItem?: "bullet" | "number";
+  level?: number;
+  markDefs: { _key: string; _type: string; href?: string }[];
+  children: PTSpan[];
+}
+
+interface PTImage {
+  _type: "image";
+  _key: string;
+  url: string;
+  alt?: string;
+}
+
+type PTNode = PTBlock | PTImage;
+
+/**
+ * 1つの inline HTML（<strong>, <em>, <a> など含む）を spans + markDefs に分解
+ */
+function parseInline(
+  html: string
+): { children: PTSpan[]; markDefs: PTBlock["markDefs"] } {
+  const markDefs: PTBlock["markDefs"] = [];
+  const children: PTSpan[] = [];
+
+  // HTML エンティティをデコード（最小限）
+  const decode = (s: string) =>
+    s
+      .replace(/&nbsp;/g, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'");
+
+  // 簡易トークナイザ: open/close タグと text を交互に
+  type Frame = { marks: string[] };
+  const stack: Frame[] = [{ marks: [] }];
+  let i = 0;
+  while (i < html.length) {
+    if (html[i] === "<") {
+      const end = html.indexOf(">", i);
+      if (end === -1) break;
+      const tag = html.slice(i + 1, end);
+      i = end + 1;
+      const isClose = tag.startsWith("/");
+      const tagName = tag
+        .replace(/^\//, "")
+        .split(/\s+/)[0]
+        .toLowerCase();
+      if (isClose) {
+        if (stack.length > 1) stack.pop();
+      } else {
+        const top = stack[stack.length - 1];
+        const newMarks = [...top.marks];
+        if (tagName === "strong" || tagName === "b") newMarks.push("strong");
+        else if (tagName === "em" || tagName === "i") newMarks.push("em");
+        else if (tagName === "a") {
+          const m = tag.match(/href="([^"]+)"/);
+          if (m) {
+            const k = key();
+            markDefs.push({ _key: k, _type: "link", href: m[1] });
+            newMarks.push(k);
+          }
+        } else if (tagName === "br") {
+          children.push({
+            _type: "span",
+            _key: key(),
+            text: "\n",
+            marks: top.marks,
+          });
+          continue; // self-closing
+        }
+        // self-closing 風（br, img）は stack に積まない
+        if (tagName !== "br" && tagName !== "img" && !tag.endsWith("/")) {
+          stack.push({ marks: newMarks });
+        }
+      }
+    } else {
+      const next = html.indexOf("<", i);
+      const text = decode(html.slice(i, next === -1 ? undefined : next));
+      if (text.length > 0) {
+        children.push({
+          _type: "span",
+          _key: key(),
+          text,
+          marks: stack[stack.length - 1].marks,
+        });
+      }
+      i = next === -1 ? html.length : next;
+    }
+  }
+
+  if (children.length === 0) {
+    children.push({ _type: "span", _key: key(), text: "", marks: [] });
+  }
+  return { children, markDefs };
+}
+
+function buildBlock(
+  style: PTBlock["style"],
+  inlineHtml: string,
+  list?: { type: "bullet" | "number"; level?: number }
+): PTBlock {
+  const { children, markDefs } = parseInline(inlineHtml);
+  const b: PTBlock = {
+    _type: "block",
+    _key: key(),
+    style,
+    markDefs,
+    children,
+  };
+  if (list) {
+    b.listItem = list.type;
+    b.level = list.level ?? 1;
+  }
+  return b;
+}
+
+function htmlToBlocks(html: string): PTNode[] {
+  const blocks: PTNode[] = [];
+
+  // ブロックレベルタグを順番に取り出す
+  const tagRe =
+    /<(p|h2|h3|h4|blockquote|ol|ul|figure|img)([^>]*)>([\s\S]*?)<\/\1>|<img([^>]*?)\/?>/gi;
+
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(html)) !== null) {
+    const tag = (m[1] || "img").toLowerCase();
+    const attrs = m[2] || m[4] || "";
+    const inner = m[3] || "";
+
+    if (tag === "p") {
+      const stripped = inner.trim();
+      if (!stripped) continue;
+      // ​（ゼロ幅）や ‍ のような不可視のみは除外
+      if (/^[​‌‍⁠\s‍]+$/.test(stripped)) continue;
+      blocks.push(buildBlock("normal", stripped));
+    } else if (tag === "h2") blocks.push(buildBlock("h2", inner));
+    else if (tag === "h3") blocks.push(buildBlock("h3", inner));
+    else if (tag === "h4") blocks.push(buildBlock("h4", inner));
+    else if (tag === "blockquote") blocks.push(buildBlock("blockquote", inner));
+    else if (tag === "ol" || tag === "ul") {
+      const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+      let li;
+      while ((li = liRe.exec(inner)) !== null) {
+        blocks.push(
+          buildBlock("normal", li[1], { type: tag === "ol" ? "number" : "bullet" })
+        );
+      }
+    } else if (tag === "figure") {
+      // figure 内の <img> を取り出す
+      const imgM = inner.match(/<img[^>]+src="([^"]+)"[^>]*alt="([^"]*)"/);
+      if (imgM) {
+        blocks.push({ _type: "image", _key: key(), url: imgM[1], alt: imgM[2] });
+      }
+    } else if (tag === "img") {
+      const srcM = attrs.match(/src="([^"]+)"/);
+      const altM = attrs.match(/alt="([^"]*)"/);
+      if (srcM) {
+        blocks.push({
+          _type: "image",
+          _key: key(),
+          url: srcM[1],
+          alt: altM?.[1] || "",
+        });
+      }
+    }
+  }
+
+  return blocks;
+}
+
+// =======================================================
+// Webflow からデータ取得
+// =======================================================
+
+async function fetchWebflowDescriptions(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  let offset = 0;
+  const limit = 100;
+  while (true) {
+    const res = await fetch(
+      `https://api.webflow.com/v2/collections/${WEBFLOW_COLLECTION_ID}/items?limit=${limit}&offset=${offset}`,
+      { headers: { Authorization: `Bearer ${WEBFLOW_TOKEN}` } }
+    );
+    if (!res.ok) {
+      console.error(`Webflow API error: ${res.status}`);
+      break;
+    }
+    const data: {
+      items: Array<{ fieldData?: { slug?: string; "description-3"?: string } }>;
+      pagination?: { total?: number };
+    } = await res.json();
+    for (const item of data.items) {
+      const slug = item.fieldData?.slug;
+      const desc = item.fieldData?.["description-3"];
+      if (slug && desc) map.set(slug, desc);
+    }
+    offset += limit;
+    if (offset >= (data.pagination?.total ?? 0)) break;
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return map;
+}
+
+// =======================================================
+// メイン
+// =======================================================
+
+async function main() {
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}\n`);
+
+  const stories: { _id: string; slug: string }[] = await client.fetch(
+    `*[_type == "story"]{ _id, "slug": slug.current }`
+  );
+
+  console.log(`対象: ${stories.length}件`);
+  console.log(`Webflow から HTML 本文取得中...`);
+  const webflowMap = await fetchWebflowDescriptions();
+  console.log(`Webflow から ${webflowMap.size} 件の HTML 取得\n`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const story of stories) {
+    const html = webflowMap.get(story.slug);
+    if (!html) {
+      console.log(`⏭  ${story.slug} → Webflow に description-3 なし`);
+      skipped++;
+      continue;
+    }
+    const blocks = htmlToBlocks(html);
+    console.log(`📝 ${story.slug} → ${blocks.length} blocks`);
+
+    if (DRY_RUN) {
+      // 最初の3 block だけサンプル表示
+      for (const b of blocks.slice(0, 3)) {
+        if (b._type === "block") {
+          const text = b.children.map((c) => c.text).join("");
+          console.log(
+            `     [${b.style}${b.listItem ? ` ${b.listItem}` : ""}] ${text.slice(0, 60)}`
+          );
+        } else if (b._type === "image") {
+          console.log(`     [image] ${b.url}`);
+        }
+      }
+      continue;
+    }
+
+    await client.patch(story._id).set({ body: blocks }).commit();
+    console.log(`     ✅ 更新完了`);
+    updated++;
+  }
+
+  console.log(`\n=== 完了 ===`);
+  console.log(`更新: ${updated} / スキップ: ${skipped} / 全 ${stories.length}`);
+}
+
+main().catch(console.error);

--- a/scripts/update-stories-premium.ts
+++ b/scripts/update-stories-premium.ts
@@ -1,0 +1,72 @@
+/**
+ * 既存 story 23件に対応する article から isPremium をコピー
+ *
+ * 実行: npx tsx scripts/update-stories-premium.ts [--dry-run]
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const writeToken = process.env.SANITY_WRITE_TOKEN;
+if (!writeToken && !DRY_RUN) {
+  console.error("⚠️  SANITY_WRITE_TOKEN が必要です");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: writeToken,
+  useCdn: false,
+});
+
+async function main() {
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}\n`);
+
+  const stories: { _id: string; slug: string }[] = await client.fetch(
+    `*[_type == "story"]{ _id, "slug": slug.current }`
+  );
+  console.log(`対象: ${stories.length}件\n`);
+
+  let updated = 0;
+  let skipped = 0;
+  let freeCount = 0;
+  let premiumCount = 0;
+
+  for (const story of stories) {
+    const article: { isPremium?: boolean } | null = await client.fetch(
+      `*[_type == "article" && slug.current == $slug][0]{isPremium}`,
+      { slug: story.slug }
+    );
+
+    if (!article) {
+      console.log(`⏭  ${story.slug} → article 不在`);
+      skipped++;
+      continue;
+    }
+
+    const isPremium = article.isPremium ?? false;
+    const label = isPremium ? "🔒 有料" : "🆓 無料";
+    console.log(`${label}  ${story.slug}  → isPremium=${isPremium}`);
+
+    if (isPremium) premiumCount++;
+    else freeCount++;
+
+    if (DRY_RUN) continue;
+
+    await client.patch(story._id).set({ isPremium }).commit();
+    updated++;
+  }
+
+  console.log(`\n=== 完了 ===`);
+  console.log(`更新: ${updated} / スキップ: ${skipped} / 全 ${stories.length}`);
+  console.log(`内訳: 🔒 有料 ${premiumCount} / 🆓 無料 ${freeCount}`);
+}
+
+main().catch(console.error);

--- a/scripts/update-stories-video.ts
+++ b/scripts/update-stories-video.ts
@@ -1,0 +1,80 @@
+/**
+ * 既存の story 23件に対応する article から videoUrl/videoDuration をコピー
+ *
+ * 実行: npx tsx scripts/update-stories-video.ts [--dry-run]
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const writeToken = process.env.SANITY_WRITE_TOKEN;
+if (!writeToken && !DRY_RUN) {
+  console.error("⚠️  SANITY_WRITE_TOKEN が必要です");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: writeToken,
+  useCdn: false,
+});
+
+async function main() {
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}\n`);
+
+  // story の slug 一覧
+  const stories: { _id: string; slug: string }[] = await client.fetch(
+    `*[_type == "story"]{ _id, "slug": slug.current }`
+  );
+
+  console.log(`対象: ${stories.length}件\n`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const story of stories) {
+    // 同じ slug の article から videoUrl, videoDuration を取得
+    const article: { videoUrl?: string; videoDuration?: string } | null =
+      await client.fetch(
+        `*[_type == "article" && slug.current == $slug][0]{videoUrl, videoDuration}`,
+        { slug: story.slug }
+      );
+
+    if (!article?.videoUrl) {
+      console.log(`⏭  ${story.slug} → article に videoUrl なし`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`📹 ${story.slug}`);
+    console.log(`   videoUrl: ${article.videoUrl}`);
+    console.log(`   videoDuration: ${article.videoDuration || "(なし)"}`);
+
+    if (DRY_RUN) {
+      console.log(`   ⏭ DRY RUN: スキップ`);
+      continue;
+    }
+
+    await client
+      .patch(story._id)
+      .set({
+        videoUrl: article.videoUrl,
+        videoDuration: article.videoDuration,
+      })
+      .commit();
+    console.log(`   ✅ 更新完了`);
+    updated++;
+  }
+
+  console.log(`\n=== 完了 ===`);
+  console.log(`更新: ${updated} / スキップ: ${skipped} / 全 ${stories.length}`);
+}
+
+main().catch(console.error);

--- a/scripts/verify-webflow-story.ts
+++ b/scripts/verify-webflow-story.ts
@@ -1,0 +1,47 @@
+/**
+ * 投入された Story を取得して、画像参照・本文ブロックの構造を確認する。
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "cqszh4up",
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2024-01-01",
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+async function main() {
+  const slug = process.argv[2] || "youhadouyatedezainani-wake";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const story: any = await client.fetch(
+    `*[_type == "story" && slug.current == $slug][0]{
+      _id, title, slug, publishedAt, excerpt, category, tags,
+      person,
+      "heroImageUrl": heroImage.asset->url,
+      "bodyBlockCount": count(body[_type == "block"]),
+      "bodyImageCount": count(body[_type == "image"]),
+      "bodyImageUrls": body[_type == "image"]{ "url": asset->url, caption, alt }
+    }`,
+    { slug }
+  );
+
+  console.log(JSON.stringify(story, null, 2));
+
+  console.log("\n=== サマリ ===");
+  console.log(`Story _id: ${story?._id}`);
+  console.log(`Title: ${story?.title}`);
+  console.log(`person.name: ${story?.person?.name}`);
+  console.log(`heroImage: ${story?.heroImageUrl ? "✓" : "✗"} ${story?.heroImageUrl ?? ""}`);
+  console.log(`Body: ${story?.bodyBlockCount} text blocks + ${story?.bodyImageCount} images`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -2,10 +2,32 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import PersonCard from "@/components/story/PersonCard";
+import { User } from "lucide-react";
 import UsedRoadmapCard from "@/components/story/UsedRoadmapCard";
 import StoryCardItem from "@/components/story/StoryCardItem";
 import RichTextSection from "@/components/article/RichTextSection";
+import ContentPreviewOverlay from "@/components/premium/ContentPreviewOverlay";
+import { getSubscriptionStatus, canAccessContent } from "@/lib/subscription";
+
+/**
+ * 動画URLから iframe embed URL を構築
+ * - Vimeo private (例: https://vimeo.com/123/abc?share=copy)
+ *   → https://player.vimeo.com/video/123?h=abc
+ * - YouTube
+ *   → https://www.youtube.com/embed/{id}
+ */
+function buildEmbedUrl(url: string): string | null {
+  const vimeo = url.match(/vimeo\.com\/(\d+)(?:\/([a-f0-9]+))?/);
+  if (vimeo) {
+    const [, id, hash] = vimeo;
+    return hash
+      ? `https://player.vimeo.com/video/${id}?h=${hash}`
+      : `https://player.vimeo.com/video/${id}`;
+  }
+  const yt = url.match(/(?:youtu\.be\/|youtube\.com\/watch\?v=)([\w-]+)/);
+  if (yt) return `https://www.youtube.com/embed/${yt[1]}`;
+  return null;
+}
 import {
   getStoryBySlug,
   getRelatedStories,
@@ -65,13 +87,23 @@ function formatPublishedAt(iso: string): string {
 
 export default async function StoryDetailPage({ params }: PageProps) {
   const { slug } = await params;
-  const story = await getStoryBySlug(slug);
+  const [story, subscription] = await Promise.all([
+    getStoryBySlug(slug),
+    getSubscriptionStatus(),
+  ]);
 
   if (!story) {
     notFound();
   }
 
-  const relatedStories = await getRelatedStories(story._id, 2);
+  const hasAccess = canAccessContent(
+    story.isPremium || false,
+    subscription.planType
+  );
+  // 動画以降を一括ブロックするかどうか
+  const showLockedContent = !!story.isPremium && !hasAccess;
+
+  const relatedStories = await getRelatedStories(story._id, 3);
 
   return (
     <div className="min-h-screen">
@@ -91,97 +123,165 @@ export default async function StoryDetailPage({ params }: PageProps) {
           </nav>
 
           <article>
-            {/* === 記事ヘッダー === */}
+            {/* === 記事ヘッダー（カードの並びに揃える）=== */}
             <header className="mb-12">
-              <div className="mb-6 flex flex-wrap items-center gap-4 text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
-                <span>{story.categoryLabel}</span>
-                {story.tags.length > 0 && (
-                  <>
-                    <span className="text-[#d4d6cc]">|</span>
-                    {story.tags.map((tag) => (
-                      <span key={tag}>#{tag}</span>
-                    ))}
-                  </>
-                )}
-                <span className="text-[#d4d6cc]">|</span>
-                <span>{formatPublishedAt(story.publishedAt)}</span>
-              </div>
+              {/* カテゴリラベル */}
+              <p className="mb-4 text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+                {story.categoryLabel}
+              </p>
 
+              {/* タイトル */}
               <h1 className="text-[28px] sm:text-[40px] lg:text-[48px] font-bold text-text-primary leading-[1.22] tracking-[-0.02em] font-noto-sans-jp">
                 {story.title}
               </h1>
 
+              {/* リード文 */}
               <p className="mt-8 text-[18px] leading-[33.3px] text-text-primary/85 font-noto-sans-jp">
                 {story.excerpt}
               </p>
+
+              {/* 人物（左）+ タグ・日付（右）— モバイルは縦積み、sm 以上は左右配置 */}
+              <div className="mt-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                {/* 左: 人物（アイコン + 名前 + 職種） */}
+                {/* アイコンは一覧と同じ person.profileImage を表示、未設定なら User フォールバック */}
+                <div className="flex items-center gap-3 min-w-0">
+                  {story.person.profileImageUrl ? (
+                    <div className="relative w-10 h-10 rounded-full overflow-hidden flex-shrink-0 bg-[#e8e9e2]">
+                      <Image
+                        src={story.person.profileImageUrl}
+                        alt={story.person.name}
+                        fill
+                        className="object-cover"
+                        unoptimized
+                      />
+                    </div>
+                  ) : (
+                    <div className="w-10 h-10 rounded-full bg-[#e8e9e2] flex items-center justify-center flex-shrink-0">
+                      <User className="w-5 h-5 text-text-primary/40" strokeWidth={1.75} />
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-sm font-bold text-text-primary font-noto-sans-jp leading-tight">
+                      {story.person.name}
+                    </p>
+                    {story.person.currentRole && (
+                      <p className="text-xs text-text-primary/60 font-noto-sans-jp mt-0.5 truncate">
+                        {story.person.currentRole}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* 右: タグ + 日付 */}
+                <div className="flex flex-wrap items-center gap-3 text-xs font-noto-sans-jp text-text-primary/60 sm:flex-shrink-0">
+                  {story.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-2.5 py-1 rounded-full bg-muted-custom"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                  <span className="text-text-primary/40">
+                    {formatPublishedAt(story.publishedAt)}
+                  </span>
+                </div>
+              </div>
             </header>
 
-            {/* アイキャッチ */}
-            {story.heroImageUrl && (
-              <div className="w-full mb-16 rounded-[8px] overflow-hidden aspect-[16/9] relative bg-[#e8e9e2]">
-                <Image
-                  src={story.heroImageUrl}
-                  alt={story.title}
-                  fill
-                  className="object-cover"
-                  unoptimized
-                  priority
+            {showLockedContent ? (
+              /* === 有料コンテンツ・未契約: 動画位置で一括ロック（/articles と同じUI） === */
+              <div className="w-full mb-16">
+                {/* 訴求コピー（ロックブロックの外・本番コンポーネントは触らない） */}
+                <p className="text-center mb-8 text-[15px] text-text-primary/70 font-noto-sans-jp leading-relaxed">
+                  BONOメンバーになると、メンバーのリアルな体験談を知ることができます。
+                </p>
+                <ContentPreviewOverlay
+                  isLoggedIn={subscription.isLoggedIn}
+                  redirectTo={`/stories/${slug}`}
                 />
               </div>
+            ) : (
+              <>
+                {/* === 動画 or アイキャッチ === */}
+                {story.videoUrl && buildEmbedUrl(story.videoUrl) ? (
+                  <div className="w-full mb-16">
+                    <div className="w-full rounded-[8px] overflow-hidden aspect-video bg-[#e8e9e2]">
+                      <iframe
+                        src={buildEmbedUrl(story.videoUrl)!}
+                        className="w-full h-full"
+                        allow="autoplay; fullscreen; picture-in-picture; clipboard-write"
+                        allowFullScreen
+                        title={story.title}
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  story.heroImageUrl && (
+                    <div className="w-full mb-16 rounded-[8px] overflow-hidden aspect-[16/9] relative bg-[#e8e9e2]">
+                      <Image
+                        src={story.heroImageUrl}
+                        alt={story.title}
+                        fill
+                        className="object-cover"
+                        unoptimized
+                        priority
+                      />
+                    </div>
+                  )
+                )}
+
+                {/* 本文（PortableText・/articles と同じ書式） */}
+                {story.body && story.body.length > 0 && (
+                  <RichTextSection content={story.body} />
+                )}
+
+                {/* 使ったロードマップ */}
+                {story.relatedRoadmaps && story.relatedRoadmaps.length > 0 && (
+                  <div className="mt-20 space-y-6">
+                    {story.relatedRoadmaps.map((roadmap) => (
+                      <UsedRoadmapCard
+                        key={roadmap._id}
+                        roadmap={roadmap}
+                        personName={story.person.name}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {/* シェアセクション */}
+                <div className="mt-20 pt-8 border-t border-[#e8e9e2] flex items-center justify-between">
+                  <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
+                    Share this story
+                  </p>
+                  <div className="flex gap-3 text-[12px] font-noto-sans-jp">
+                    <Link
+                      href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(story.title)}&url=${encodeURIComponent(`https://bono.training/stories/${slug}`)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-text-primary hover:underline underline-offset-4"
+                    >
+                      Xでシェア
+                    </Link>
+                  </div>
+                </div>
+              </>
             )}
-
-            {/* 人物プロフィールカード */}
-            <div className="mb-16">
-              <PersonCard person={story.person} />
-            </div>
-
-            {/* 本文（PortableText・/articles と同じ書式） */}
-            <RichTextSection content={story.body} />
-
-            {/* 使ったロードマップ */}
-            {story.relatedRoadmaps && story.relatedRoadmaps.length > 0 && (
-              <div className="mt-20 space-y-6">
-                {story.relatedRoadmaps.map((roadmap) => (
-                  <UsedRoadmapCard
-                    key={roadmap._id}
-                    roadmap={roadmap}
-                    personName={story.person.name}
-                  />
-                ))}
-              </div>
-            )}
-
-            {/* シェアセクション */}
-            <div className="mt-20 pt-8 border-t border-[#e8e9e2] flex items-center justify-between">
-              <p className="text-[11px] tracking-[1.2px] uppercase text-[#677470] font-noto-sans-jp">
-                Share this story
-              </p>
-              <div className="flex gap-3 text-[12px] font-noto-sans-jp">
-                <Link
-                  href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(story.title)}&url=${encodeURIComponent(`https://bono.training/stories/${slug}`)}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-text-primary hover:underline underline-offset-4"
-                >
-                  Xでシェア
-                </Link>
-              </div>
-            </div>
           </article>
         </div>
       </main>
 
       {/* 他のストーリー */}
       {relatedStories.length > 0 && (
-        <section className="bg-white border-t border-[#e8e9e2]">
-          <div className="max-w-[1000px] mx-auto px-4 sm:px-6 py-20">
+        <section className="border-t border-[#e8e9e2]">
+          <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-20">
             <p className="text-[11px] tracking-[1.68px] uppercase text-[#677470] font-noto-sans-jp mb-3 text-center">
               More Stories
             </p>
             <h2 className="text-[24px] sm:text-[28px] font-bold text-text-primary text-center font-rounded-mplus leading-tight">
               他のストーリー
             </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-12">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-12">
               {relatedStories.map((s) => (
                 <StoryCardItem key={s._id} story={s} />
               ))}

--- a/src/components/article/RichTextSection.tsx
+++ b/src/components/article/RichTextSection.tsx
@@ -23,7 +23,7 @@ interface RichTextSectionProps {
  */
 const generateHeadingId = (
   children: React.ReactNode,
-  index: number
+  key: string
 ): string => {
   const text =
     typeof children === "string"
@@ -38,7 +38,7 @@ const generateHeadingId = (
           .join("")
       : "";
 
-  return `heading-${index}-${text
+  return `heading-${key}-${text
     .toLowerCase()
     .replace(/\s+/g, "-")
     .replace(/[^\w\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf-]/g, "")}`;
@@ -75,14 +75,12 @@ const RichTextSection = ({
   // プレミアムコンテンツで未契約の場合、最初のブロックのみ表示
   const displayContent =
     isPremium && !hasAccess ? content.slice(0, previewBlockCount) : content;
-  // 見出しのインデックスを追跡するためのカウンター
-  let headingIndex = 0;
 
   const components: PortableTextComponents = {
     block: {
       // Heading 2: 24px(desktop) / 20px(mobile), semibold, lh:32px
-      h2: ({ children }) => {
-        const id = generateHeadingId(children, headingIndex++);
+      h2: ({ children, value }) => {
+        const id = generateHeadingId(children, value._key || "");
         return (
           <h2
             id={id}
@@ -94,8 +92,8 @@ const RichTextSection = ({
         );
       },
       // Heading 3: 20px(desktop) / 18px(mobile), semibold, lh:28px
-      h3: ({ children }) => {
-        const id = generateHeadingId(children, headingIndex++);
+      h3: ({ children, value }) => {
+        const id = generateHeadingId(children, value._key || "");
         return (
           <h3
             id={id}
@@ -107,8 +105,8 @@ const RichTextSection = ({
         );
       },
       // Heading 4: 18px(desktop) / 16px(mobile), semibold, lh:24px
-      h4: ({ children }) => {
-        const id = generateHeadingId(children, headingIndex++);
+      h4: ({ children, value }) => {
+        const id = generateHeadingId(children, value._key || "");
         return (
           <h4
             id={id}

--- a/src/components/video/VimeoFallbackPlayer.tsx
+++ b/src/components/video/VimeoFallbackPlayer.tsx
@@ -15,6 +15,8 @@ export function VimeoFallbackPlayer({
   className = "",
 }: VimeoFallbackPlayerProps) {
   const extractedId = extractVimeoId(vimeoId);
+  const extractedHash = extractVimeoHash(vimeoId);
+  const hashQuery = extractedHash ? `&h=${extractedHash}` : "";
 
   return (
     <div
@@ -22,7 +24,7 @@ export function VimeoFallbackPlayer({
     >
       <div className="w-full aspect-video">
         <iframe
-          src={`https://player.vimeo.com/video/${extractedId}?title=0&byline=0&portrait=0`}
+          src={`https://player.vimeo.com/video/${extractedId}?title=0&byline=0&portrait=0${hashQuery}`}
           className="w-full h-full"
           frameBorder="0"
           allow="autoplay; fullscreen; picture-in-picture"
@@ -40,4 +42,13 @@ function extractVimeoId(url: string): string {
   }
   const match = url.match(/(?:vimeo\.com\/|player\.vimeo\.com\/video\/)(\d+)/);
   return match ? match[1] : url;
+}
+
+function extractVimeoHash(url: string): string | null {
+  if (/^\d+$/.test(url)) return null;
+  const pathMatch = url.match(/vimeo\.com\/\d+\/([a-f0-9]+)/);
+  if (pathMatch) return pathMatch[1];
+  const queryMatch = url.match(/[?&]h=([a-f0-9]+)/);
+  if (queryMatch) return queryMatch[1];
+  return null;
 }

--- a/src/components/video/hooks/useVimeoPlayer.ts
+++ b/src/components/video/hooks/useVimeoPlayer.ts
@@ -76,13 +76,15 @@ export function useVimeoPlayer(vimeoId: string, options: VimeoPlayerOptions = {}
       playerRef.current.destroy();
     }
 
-    // Vimeo IDを抽出（URLの場合）
+    // Vimeo IDと private hash を抽出（URLの場合）
     const extractedId = extractVimeoId(vimeoId);
+    const extractedHash = extractVimeoHash(vimeoId);
 
-    console.log('[VimeoPlayer] Initializing with ID:', extractedId);
+    console.log('[VimeoPlayer] Initializing with ID:', extractedId, 'hash:', extractedHash ?? '(none)');
 
     const player = new Player(containerRef.current, {
       id: parseInt(extractedId, 10),
+      ...(extractedHash ? { h: extractedHash } : {}),
       controls: false,  // Vimeo標準UIを非表示（Plusプラン以上で有効）
       responsive: true,
       title: false,
@@ -370,4 +372,21 @@ function extractVimeoId(url: string): string {
   }
   const match = url.match(/(?:vimeo\.com\/|player\.vimeo\.com\/video\/)(\d+)/);
   return match ? match[1] : url;
+}
+
+/**
+ * Vimeo URLから private hash を抽出する。
+ * 例: https://vimeo.com/1027603200/2dc830c8cb?share=copy → "2dc830c8cb"
+ * 例: https://player.vimeo.com/video/1027603200?h=2dc830c8cb → "2dc830c8cb"
+ * 公開動画の場合は null。
+ */
+function extractVimeoHash(url: string): string | null {
+  if (/^\d+$/.test(url)) return null;
+  // パスに含まれる /vimeo.com/{id}/{hash}
+  const pathMatch = url.match(/vimeo\.com\/\d+\/([a-f0-9]+)/);
+  if (pathMatch) return pathMatch[1];
+  // クエリで ?h={hash}
+  const queryMatch = url.match(/[?&]h=([a-f0-9]+)/);
+  if (queryMatch) return queryMatch[1];
+  return null;
 }

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -1347,6 +1347,9 @@ const STORY_SUMMARY_FIELDS = `
   excerpt,
   heroImage,
   "heroImageUrl": heroImage.asset->url,
+  videoUrl,
+  videoDuration,
+  isPremium,
   category,
   tags,
   person {
@@ -1366,6 +1369,9 @@ const STORY_DETAIL_FIELDS = `
   excerpt,
   heroImage,
   "heroImageUrl": heroImage.asset->url,
+  videoUrl,
+  videoDuration,
+  isPremium,
   category,
   tags,
   person {
@@ -1384,7 +1390,16 @@ const STORY_DETAIL_FIELDS = `
     description,
     "thumbnailUrl": thumbnail.asset->url,
   },
-  body
+  body[] {
+    ...,
+    _type == "image" => {
+      ...,
+      "asset": asset-> {
+        _id,
+        url
+      }
+    }
+  }
 `;
 
 function attachStoryCategoryLabel<T extends { category: string }>(item: T): T & { categoryLabel: string } {
@@ -1401,7 +1416,7 @@ export const getStoriesList = unstable_cache(
     const results = await getClient().fetch<StorySummary[]>(query);
     return results.map(attachStoryCategoryLabel);
   },
-  ["sanity:stories:list"],
+  ["sanity:stories:list:v3"],
   { tags: ["story"], revalidate: 3600 }
 );
 
@@ -1414,7 +1429,7 @@ export const getStoryBySlug = unstable_cache(
     const result = await getClient().fetch<Story | null>(query, { slug });
     return result ? attachStoryCategoryLabel(result) : null;
   },
-  ["sanity:stories:bySlug"],
+  ["sanity:stories:bySlug:v3"],
   { tags: ["story"], revalidate: 3600 }
 );
 
@@ -1427,7 +1442,7 @@ export const getRelatedStories = unstable_cache(
     const results = await getClient().fetch<StorySummary[]>(query, { excludeId });
     return results.map(attachStoryCategoryLabel);
   },
-  ["sanity:stories:related"],
+  ["sanity:stories:related:v3"],
   { tags: ["story"], revalidate: 3600 }
 );
 

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -362,6 +362,9 @@ export interface StorySummary {
   excerpt: string;
   heroImage?: SanityImage;
   heroImageUrl?: string;
+  videoUrl?: string;
+  videoDuration?: string;
+  isPremium?: boolean;
   category: StoryCategory;
   categoryLabel: string;
   tags: string[];
@@ -378,6 +381,9 @@ export interface Story {
   excerpt: string;
   heroImage?: SanityImage;
   heroImageUrl?: string;
+  videoUrl?: string;
+  videoDuration?: string;
+  isPremium?: boolean;
   person: StoryPerson;
   category: StoryCategory;
   categoryLabel: string;


### PR DESCRIPTION
## Summary
PR #120 でマージ済みの受講者ストーリー機能に対する追加修正。Webflow 記事の Sanity 投入対応と、本文画像の表示バグ修正、ストーリー詳細 UI 改善を含みます。

## 主な変更

### バグ修正
- 本文 GROQ で image asset の `->url` を解決（body 内画像が表示されないバグ）
- RichTextSection: 見出し ID を `block._key` ベースにして hydration mismatch を解消
- Vimeo private hash (`h=xxx`) に対応

### UI 改善
- ストーリー詳細から `PersonCard` を削除し、ヘッダー部に人物アイコン + 名前 + 職種を集約
- 人物アイコンは `person.profileImage` を表示、未設定なら lucide-react の User アイコンをフォールバック

### スキーマ
- `Story` / `StorySummary` 型に `videoUrl` / `videoDuration` / `isPremium` を追加

### ツール（scripts/）
- `import-webflow-story.ts`: Webflow 記事を Sanity Story に投入（HTML → Portable Text、画像も Sanity Assets に upload）
- `inspect-webflow-*.ts`: Webflow Item の構造確認用
- `diff-webflow-sanity.ts`: 投入後の突合確認用
- `verify-webflow-story.ts`: 投入後の検証用
- `update-stories-*.ts`: 既存 story の一括更新用ユーティリティ

## Test plan
- [ ] `/stories/youhadouyatedezainani-wake` で本文画像 4 枚が表示される
- [ ] 同ページの h2 で hydration warning が出ない
- [ ] `/stories` 一覧に和家くん含む全ストーリーが表示される（キャッシュ反映後）
- [ ] ストーリー詳細のヘッダーに人物アイコン + 名前が出る

## 関連
- 後継 PR (#121 はコンフリクトのため close 予定): https://github.com/kaikunnnn/bono-training/pull/121

🤖 Generated with [Claude Code](https://claude.com/claude-code)