### PR TITLE
feat: lesson に SEO 必須フィールドを追加（subtitle / seoTitle）

### DIFF
--- a/src/app/lessons/[slug]/page.tsx
+++ b/src/app/lessons/[slug]/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     };
   }
 
-  const title = `${lesson.title} | BONO`;
+  const title = `${lesson.seoTitle || lesson.title} | BONO`;
   const description = lesson.description || `${lesson.title}のレッスン内容を学習できます。`;
   const imageUrl = lesson.thumbnailUrl || lesson.iconImageUrl;
 

--- a/src/components/lesson/header/LessonTitleArea.tsx
+++ b/src/components/lesson/header/LessonTitleArea.tsx
@@ -15,6 +15,7 @@ interface LinkedRoadmap {
 interface LessonTitleAreaProps {
   lesson: {
     title: string;
+    subtitle?: string;
     category?: string;
     description?: string;
     linkedRoadmaps?: LinkedRoadmap[];
@@ -55,6 +56,11 @@ export function LessonTitleArea({
         <h1 className="font-rounded-mplus font-bold text-[32px] text-training-dark leading-[40px] w-full">
           {lesson.title}
         </h1>
+        {lesson.subtitle && (
+          <h2 className="font-noto-sans-jp font-medium text-[16px] text-text-muted leading-[1.5] w-full">
+            {lesson.subtitle}
+          </h2>
+        )}
         {/* ロードマップ紐づき表示 */}
         {lesson.linkedRoadmaps && lesson.linkedRoadmaps.length > 0 && (
           <div className="flex items-center gap-1 text-[rgba(13,34,29,0.48)]">

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -50,6 +50,8 @@ export const getLesson = unstable_cache(
       _id,
       _type,
       title,
+      subtitle,
+      seoTitle,
       slug,
       description,
       lessonNumber,
@@ -143,6 +145,7 @@ export const getLessonMetadata = unstable_cache(
     const query = `
       *[_type == "lesson" && slug.current == $slug][0] {
         title,
+        seoTitle,
         description,
         "thumbnailUrl": coalesce(thumbnailUrl, thumbnail.asset->url),
         "iconImageUrl": coalesce(iconImageUrl, iconImage.asset->url)

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -70,6 +70,8 @@ export interface Lesson {
   _id: string;
   _type: "lesson";
   title: string;
+  subtitle?: string;
+  seoTitle?: string;
   slug: SanitySlug;
   description?: string;
   lessonNumber?: number;
@@ -324,6 +326,7 @@ export interface LessonWithDetails extends Omit<Lesson, "quests" | "category"> {
 // OGP用メタデータ
 export interface LessonMetadata {
   title: string;
+  seoTitle?: string;
   description?: string;
   thumbnailUrl?: string;
   iconImageUrl?: string;


### PR DESCRIPTION
## Summary

レッスン詳細ページの SEO 流入最大化のため、Sanity の lesson スキーマと Next.js 側に SEO 必須フィールドを追加。

- **subtitle**: H2（KW 補強用サブタイトル）
- **seoTitle**: `<title>` タグ専用（〜70字、未入力時は title を流用）
- **description**: 既存フィールドを meta description と兼用（160字 warning）

H1 = `title`（UI 見出し、短く）と `<title>` タグ = `seoTitle`（KW を詰めて長く）を別管理することで、UI 体験と SEO 訴求を両立する。

## 変更ファイル

- `src/types/sanity.ts` — Lesson / LessonMetadata に `subtitle` / `seoTitle` を追加
- `src/lib/sanity.ts` — getLesson / getLessonMetadata クエリに新フィールドを追加
- `src/app/lessons/[slug]/page.tsx` — `generateMetadata` で `seoTitle || title` を出力
- `src/components/lesson/header/LessonTitleArea.tsx` — H1 直下に H2（subtitle）を追加（subtitle 未入力時は非表示）

## 別途必要な作業

- **Sanity Studio リポジトリ（bono-training）側**: `schemaTypes/lesson.ts` に `subtitle` / `seoTitle` フィールドを追加 → 別 PR で対応

## 互換性

- 既存レッスンは `subtitle` / `seoTitle` 未入力なので**表示変更なし**
- subtitle を入力したレッスンだけ H2 が表示される
- seoTitle 未入力時は従来通り `title` が `<title>` タグに使われる

## Test plan

- [ ] 既存レッスンページが従来通り表示される（subtitle 未入力で H2 が出ない）
- [ ] Sanity 側で `tutorial-uivisual` に subtitle / seoTitle を入力 → 反映確認
- [ ] HTML ソースで `<title>` タグに seoTitle が反映される
- [ ] HTML ソースで `<meta name="description">` に description が反映される
- [ ] `npm run build` が通る
- [ ] `npx tsc --noEmit` が通る

ref: `rebono/issues/Sanity_コースSchema_SEO必須フィールド.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)