### PR TITLE
feat(search): /search + AI アシスタント + サイドバー検索を Next.js 版に移植 (#111)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bono-training-nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.89.0",
         "@portabletext/react": "^6.0.3",
         "@portabletext/types": "^4.0.2",
         "@sanity/client": "^7.16.0",
@@ -15,6 +16,7 @@
         "@sanity/webhook": "^4.0.4",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.98.0",
+        "@tanstack/react-query": "^5.101.0",
         "@types/canvas-confetti": "^1.9.0",
         "@vimeo/player": "^2.30.1",
         "canvas-confetti": "^1.9.4",
@@ -24,6 +26,7 @@
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.36.0",
         "gray-matter": "^4.0.3",
+        "groq-sdk": "^1.3.0",
         "iconsax-react": "^0.0.8",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.577.0",
@@ -103,6 +106,26 @@
         "nr": "bin/nr.mjs",
         "nun": "bin/nun.mjs",
         "nup": "bin/nup.mjs"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.89.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.89.0.tgz",
+      "integrity": "sha512-nyGau0zex62EpU91hsHa0zod973YEoiMgzWZ9hC55WdiOLrE4AGpcg4wXI7lFqtvMLqMcLfewQU9sHgQB6psow==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -549,7 +572,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5392,6 +5414,32 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -9855,6 +9903,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/groq-sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-1.3.0.tgz",
+      "integrity": "sha512-mvgUIpAxlk/VxWIoliHx4R+Ha78Bd/g0t24OFjCXtdLbNiY1rW4h9AcznKBwFho7K/Nq732ZSjxMYkNb1xeCFg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "groq-sdk": "bin/cli"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -11062,6 +11119,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -15714,6 +15784,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -17526,7 +17602,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.89.0",
     "@portabletext/react": "^6.0.3",
     "@portabletext/types": "^4.0.2",
     "@sanity/client": "^7.16.0",
@@ -19,6 +20,7 @@
     "@sanity/webhook": "^4.0.4",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
+    "@tanstack/react-query": "^5.101.0",
     "@types/canvas-confetti": "^1.9.0",
     "@vimeo/player": "^2.30.1",
     "canvas-confetti": "^1.9.4",
@@ -28,6 +30,7 @@
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.36.0",
     "gray-matter": "^4.0.3",
+    "groq-sdk": "^1.3.0",
     "iconsax-react": "^0.0.8",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.577.0",

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -1,0 +1,287 @@
+import { NextRequest } from "next/server";
+import Groq from "groq-sdk";
+import { client } from "@/lib/sanity";
+
+// Edge ではなく Node.js 環境で実行（Groq SDK の streaming に必要）
+export const runtime = "nodejs";
+
+const groq = new Groq({ apiKey: process.env.GROQ_API_KEY || "" });
+
+// ============================================================
+// Sanity コンテンツ取得（Vite 版の構造をそのまま踏襲）
+// ============================================================
+
+async function fetchContext() {
+  const sanity = client();
+  const [lessons, guides, roadmaps] = await Promise.all([
+    // Lesson + Quest + Article の階層を一括取得
+    sanity.fetch(`*[_type == "lesson"] | order(_createdAt desc)[0...30] {
+      _id,
+      title,
+      "slug": slug.current,
+      description,
+      "category": category->title,
+      tags,
+      isPremium,
+      "quests": *[_type == "quest" && references(^._id)] | order(questNumber asc) {
+        questNumber,
+        title,
+        goal,
+        "articles": articles[]->{
+          articleNumber,
+          title,
+          "slug": slug.current,
+          excerpt,
+          articleType,
+          contentType,
+          isPremium
+        }
+      }
+    }`),
+    sanity.fetch(`*[_type == "guide"] | order(publishedAt desc)[0...30] {
+      _id,
+      title,
+      "slug": slug.current,
+      description,
+      category,
+      tags,
+      isPremium
+    }`),
+    sanity.fetch(`*[_type == "roadmap" && isPublished == true] | order(order asc)[0...20] {
+      _id,
+      title,
+      "slug": slug.current,
+      description,
+      tags,
+      estimatedDuration
+    }`),
+  ]);
+
+  return { lessons, guides, roadmaps };
+}
+
+const ARTICLE_TYPE_LABEL: Record<string, string> = {
+  explain: "知識",
+  intro: "イントロ",
+  practice: "実践",
+  challenge: "チャレンジ",
+  demo: "実演解説",
+};
+
+interface SanityArticle {
+  articleNumber?: number;
+  title: string;
+  slug: string;
+  excerpt?: string;
+  articleType?: string;
+  contentType?: string;
+  isPremium?: boolean;
+}
+interface SanityQuest {
+  questNumber?: number;
+  title: string;
+  goal?: string;
+  articles?: SanityArticle[];
+}
+interface SanityLesson {
+  _id: string;
+  title: string;
+  slug: string;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  isPremium?: boolean;
+  quests?: SanityQuest[];
+}
+interface SanityGuide {
+  _id: string;
+  title: string;
+  slug: string;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  isPremium?: boolean;
+}
+interface SanityRoadmap {
+  _id: string;
+  title: string;
+  slug: string;
+  description?: string;
+  tags?: string[];
+  estimatedDuration?: string;
+}
+
+function buildContextText(
+  lessons: SanityLesson[],
+  guides: SanityGuide[],
+  roadmaps: SanityRoadmap[]
+): string {
+  const lines: string[] = [];
+
+  lines.push("## ロードマップ（学習パス）");
+  for (const r of roadmaps) {
+    lines.push(
+      `- [${r.title}](/roadmaps/${r.slug}): ${r.description || ""}${
+        r.estimatedDuration ? ` (目安: ${r.estimatedDuration})` : ""
+      }`
+    );
+    if (r.tags?.length) lines.push(`  タグ: ${r.tags.join(", ")}`);
+  }
+
+  lines.push("\n## レッスン（コース）");
+  for (const l of lessons) {
+    const premium = l.isPremium ? " [有料]" : "";
+    lines.push(`### [${l.title}](/lessons/${l.slug})${premium}`);
+    if (l.description) lines.push(`概要: ${l.description}`);
+    if (l.tags?.length) lines.push(`タグ: ${l.tags.join(", ")}`);
+
+    if (l.quests?.length) {
+      for (const q of l.quests) {
+        lines.push(
+          `  ▸ Quest${q.questNumber || ""} 「${q.title}」${
+            q.goal ? ` — ${q.goal}` : ""
+          }`
+        );
+        if (q.articles?.length) {
+          for (const a of q.articles) {
+            const aType = ARTICLE_TYPE_LABEL[a.articleType || ""] || a.articleType || "";
+            const aPremium = a.isPremium ? "[有料]" : "";
+            const aExcerpt = a.excerpt ? ` — ${a.excerpt}` : "";
+            lines.push(
+              `    - [${a.title}](/lessons/${l.slug}?article=${a.slug}) [${aType}]${aPremium}${aExcerpt}`
+            );
+          }
+        }
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("\n## ガイド（読み物）");
+  const categoryLabel: Record<string, string> = {
+    career: "キャリア",
+    learning: "学習方法",
+    industry: "業界動向",
+    tools: "ツール・技術",
+  };
+  for (const g of guides) {
+    const premium = g.isPremium ? " [有料]" : "";
+    lines.push(`- [${g.title}](/guide/${g.slug})${premium}: ${g.description || ""}`);
+    if (g.category) lines.push(`  カテゴリ: ${categoryLabel[g.category] ?? g.category}`);
+    if (g.tags?.length) lines.push(`  タグ: ${g.tags.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
+
+const SYSTEM_PROMPT = `あなたはBONO（UIUXデザイン学習サービス）のラーニングアシスタントです。
+ユーザーの質問や悩みに対して、BONOのコンテンツを活用して具体的な学習アドバイスを提供します。
+
+## あなたの役割
+- ユーザーの現状と目標を理解する
+- 学習ステップを飛ばしていそうな場合は、正しい順序を提案する
+- BONOの具体的なコンテンツ（ロードマップ・レッスン・ガイド）を引用してアドバイスする
+- リンクは必ずMarkdown形式 [タイトル](URL) で記述する
+- URLは必ずコンテンツ一覧に記載された相対パス（/lessonsや/roadmaps で始まる形式）をそのまま使う。絶対URLや存在しないURLは絶対に作らない
+
+## 回答の構成
+1. ユーザーの状況の整理（1〜2文）
+2. まず取り組むべきことの提案（BONOコンテンツを引用。Quest・記事レベルで具体的に）
+3. 元の質問への具体的な回答
+
+## 注意事項
+- BONOにないコンテンツは「BONOには現在ありませんが〜」と正直に伝える
+- レッスン内の特定のQuestや記事を推薦する場合は、コンテンツ一覧に記載されたリンクを使う
+- 返答は簡潔に。長くなる場合は箇条書きを活用する
+- 日本語で回答する`;
+
+interface IncomingChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+// ============================================================
+// POST ハンドラ
+// ============================================================
+
+export async function POST(req: NextRequest) {
+  let messages: IncomingChatMessage[];
+  try {
+    const body = await req.json();
+    messages = body.messages;
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!messages || !Array.isArray(messages) || messages.length === 0) {
+    return new Response(JSON.stringify({ error: "messages is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { lessons, guides, roadmaps } = await fetchContext();
+    const contextText = buildContextText(
+      lessons as SanityLesson[],
+      guides as SanityGuide[],
+      roadmaps as SanityRoadmap[]
+    );
+
+    const systemWithContext = `${SYSTEM_PROMPT}\n\n## BONOで学べるコンテンツ一覧\n${contextText}`;
+
+    const groqMessages: Groq.Chat.ChatCompletionMessageParam[] = [
+      { role: "system", content: systemWithContext },
+      ...messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+    ];
+
+    const stream = await groq.chat.completions.create({
+      model: "llama-3.3-70b-versatile",
+      messages: groqMessages,
+      stream: true,
+      max_tokens: 1024,
+    });
+
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        try {
+          for await (const chunk of stream) {
+            const text = chunk.choices[0]?.delta?.content || "";
+            if (text) {
+              controller.enqueue(
+                encoder.encode(`data: ${JSON.stringify({ text })}\n\n`)
+              );
+            }
+          }
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        } catch (err) {
+          console.error("[ai-chat stream]", err);
+        } finally {
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(readable, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  } catch (error) {
+    console.error("[ai-chat] Error:", error);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -13,46 +13,34 @@ const groq = new Groq({ apiKey: process.env.GROQ_API_KEY || "" });
 
 async function fetchContext() {
   const sanity = client();
+  // Groq の payload 制限（413）回避のため取得を絞る
+  // - lessons: 最新 20、Quest タイトルだけ（articles 展開なし、tags 省略）
+  // - guides: 最新 20、description は省略してタイトル + カテゴリのみ
+  // - roadmaps: 最新 15、description は短めに
   const [lessons, guides, roadmaps] = await Promise.all([
-    // Lesson + Quest + Article の階層を一括取得
-    sanity.fetch(`*[_type == "lesson"] | order(_createdAt desc)[0...30] {
-      _id,
+    sanity.fetch(`*[_type == "lesson"] | order(_createdAt desc)[0...20] {
       title,
       "slug": slug.current,
       description,
       "category": category->title,
-      tags,
       isPremium,
       "quests": *[_type == "quest" && references(^._id)] | order(questNumber asc) {
         questNumber,
         title,
-        goal,
-        "articles": articles[]->{
-          articleNumber,
-          title,
-          "slug": slug.current,
-          excerpt,
-          articleType,
-          contentType,
-          isPremium
-        }
+        goal
       }
     }`),
-    sanity.fetch(`*[_type == "guide"] | order(publishedAt desc)[0...30] {
-      _id,
+    sanity.fetch(`*[_type == "guide"] | order(publishedAt desc)[0...20] {
       title,
       "slug": slug.current,
       description,
       category,
-      tags,
       isPremium
     }`),
-    sanity.fetch(`*[_type == "roadmap" && isPublished == true] | order(order asc)[0...20] {
-      _id,
+    sanity.fetch(`*[_type == "roadmap" && isPublished == true] | order(order asc)[0...15] {
       title,
       "slug": slug.current,
       description,
-      tags,
       estimatedDuration
     }`),
   ]);
@@ -60,56 +48,36 @@ async function fetchContext() {
   return { lessons, guides, roadmaps };
 }
 
-const ARTICLE_TYPE_LABEL: Record<string, string> = {
-  explain: "知識",
-  intro: "イントロ",
-  practice: "実践",
-  challenge: "チャレンジ",
-  demo: "実演解説",
-};
-
-interface SanityArticle {
-  articleNumber?: number;
-  title: string;
-  slug: string;
-  excerpt?: string;
-  articleType?: string;
-  contentType?: string;
-  isPremium?: boolean;
-}
 interface SanityQuest {
   questNumber?: number;
   title: string;
   goal?: string;
-  articles?: SanityArticle[];
 }
 interface SanityLesson {
-  _id: string;
   title: string;
   slug: string;
   description?: string;
   category?: string;
-  tags?: string[];
   isPremium?: boolean;
   quests?: SanityQuest[];
 }
 interface SanityGuide {
-  _id: string;
   title: string;
   slug: string;
   description?: string;
   category?: string;
-  tags?: string[];
   isPremium?: boolean;
 }
 interface SanityRoadmap {
-  _id: string;
   title: string;
   slug: string;
   description?: string;
-  tags?: string[];
   estimatedDuration?: string;
 }
+
+/** 文字列を最大 N 文字に切り詰め */
+const truncate = (s: string | undefined, max: number): string =>
+  s && s.length > max ? s.slice(0, max) + "…" : s || "";
 
 function buildContextText(
   lessons: SanityLesson[],
@@ -121,38 +89,25 @@ function buildContextText(
   lines.push("## ロードマップ（学習パス）");
   for (const r of roadmaps) {
     lines.push(
-      `- [${r.title}](/roadmaps/${r.slug}): ${r.description || ""}${
+      `- [${r.title}](/roadmaps/${r.slug}): ${truncate(r.description, 80)}${
         r.estimatedDuration ? ` (目安: ${r.estimatedDuration})` : ""
       }`
     );
-    if (r.tags?.length) lines.push(`  タグ: ${r.tags.join(", ")}`);
   }
 
   lines.push("\n## レッスン（コース）");
   for (const l of lessons) {
     const premium = l.isPremium ? " [有料]" : "";
     lines.push(`### [${l.title}](/lessons/${l.slug})${premium}`);
-    if (l.description) lines.push(`概要: ${l.description}`);
-    if (l.tags?.length) lines.push(`タグ: ${l.tags.join(", ")}`);
+    if (l.description) lines.push(`概要: ${truncate(l.description, 120)}`);
+    if (l.category) lines.push(`カテゴリ: ${l.category}`);
 
+    // Quest はタイトルのみ簡潔に列挙（article 展開は payload 削減のためスキップ）
     if (l.quests?.length) {
-      for (const q of l.quests) {
-        lines.push(
-          `  ▸ Quest${q.questNumber || ""} 「${q.title}」${
-            q.goal ? ` — ${q.goal}` : ""
-          }`
-        );
-        if (q.articles?.length) {
-          for (const a of q.articles) {
-            const aType = ARTICLE_TYPE_LABEL[a.articleType || ""] || a.articleType || "";
-            const aPremium = a.isPremium ? "[有料]" : "";
-            const aExcerpt = a.excerpt ? ` — ${a.excerpt}` : "";
-            lines.push(
-              `    - [${a.title}](/lessons/${l.slug}?article=${a.slug}) [${aType}]${aPremium}${aExcerpt}`
-            );
-          }
-        }
-      }
+      const questLine = l.quests
+        .map((q) => `Q${q.questNumber || ""}:${q.title}`)
+        .join(" / ");
+      lines.push(`  Quests: ${questLine}`);
     }
     lines.push("");
   }
@@ -166,9 +121,10 @@ function buildContextText(
   };
   for (const g of guides) {
     const premium = g.isPremium ? " [有料]" : "";
-    lines.push(`- [${g.title}](/guide/${g.slug})${premium}: ${g.description || ""}`);
-    if (g.category) lines.push(`  カテゴリ: ${categoryLabel[g.category] ?? g.category}`);
-    if (g.tags?.length) lines.push(`  タグ: ${g.tags.join(", ")}`);
+    const cat = g.category ? ` [${categoryLabel[g.category] ?? g.category}]` : "";
+    lines.push(
+      `- [${g.title}](/guide/${g.slug})${premium}${cat}: ${truncate(g.description, 80)}`
+    );
   }
 
   return lines.join("\n");

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,258 @@
+import { NextRequest } from "next/server";
+import { createClient } from "@sanity/client";
+import type {
+  SearchResult,
+  LessonSearchResult,
+  ArticleSearchResult,
+  GuideSearchResult,
+} from "@/types/search";
+
+// Node.js ランタイム（Sanity SDK の互換性）
+export const runtime = "nodejs";
+
+// Vercel Edge / Node の CDN キャッシュ：5 分 fresh、10 分 SWR
+// クライアントの React Query にも staleTime 5 分があるので二重で守る
+export const revalidate = 300;
+
+// 検索専用 Sanity client（useCdn:true で高速化）
+const sanity = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
+  apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2024-01-01",
+  useCdn: true,
+});
+
+// ============================================================
+// Sanity データ型
+// ============================================================
+
+interface SanityLessonForSearch {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  description?: string;
+  thumbnailUrl?: string;
+  categoryTitle?: string;
+  tags?: string[];
+  isPremium?: boolean;
+  articleCount: number;
+  linkedRoadmaps?: { slug: string; title: string; shortTitle?: string }[];
+}
+
+interface SanityArticleForSearch {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  excerpt?: string;
+  thumbnailUrl?: string;
+  tags?: string[];
+  isPremium?: boolean;
+  videoDuration?: string | number;
+  lessonTitle?: string;
+  lessonSlug?: string;
+}
+
+interface SanityGuideForSearch {
+  _id: string;
+  title: string;
+  slug: string;
+  description?: string;
+  thumbnailUrl?: string;
+  category?: string;
+  tags?: string[];
+  publishedAt?: string;
+  readingTime?: string;
+  isPremium?: boolean;
+}
+
+// ============================================================
+// Sanity フェッチ
+// ============================================================
+
+async function fetchLessonsForSearch(): Promise<SanityLessonForSearch[]> {
+  const query = `*[_type == "lesson"] | order(_createdAt desc) {
+    _id,
+    title,
+    slug,
+    description,
+    "thumbnailUrl": coalesce(
+      iconImageUrl,
+      iconImage.asset->url,
+      thumbnailUrl,
+      thumbnail.asset->url
+    ),
+    "categoryTitle": category->title,
+    tags,
+    isPremium,
+    "articleCount": count(quests[]->articles[]),
+    "linkedRoadmaps": *[_type == "roadmap" && references(^._id)] {
+      "slug": slug.current,
+      title,
+      shortTitle
+    }
+  }`;
+  return sanity.fetch(query);
+}
+
+async function fetchArticlesForSearch(): Promise<SanityArticleForSearch[]> {
+  const query = `*[_type == "lesson"] {
+    "lessonTitle": title,
+    "lessonSlug": slug.current,
+    "articles": quests[]->articles[]-> {
+      _id,
+      title,
+      slug,
+      excerpt,
+      "thumbnailUrl": coalesce(thumbnailUrl, thumbnail.asset->url),
+      tags,
+      isPremium,
+      videoDuration
+    }
+  }`;
+  const lessons = await sanity.fetch<
+    {
+      lessonTitle: string;
+      lessonSlug: string;
+      articles: SanityArticleForSearch[];
+    }[]
+  >(query);
+  const all: SanityArticleForSearch[] = [];
+  for (const lesson of lessons) {
+    if (lesson.articles) {
+      for (const article of lesson.articles) {
+        if (article) {
+          all.push({
+            ...article,
+            lessonTitle: lesson.lessonTitle,
+            lessonSlug: lesson.lessonSlug,
+          });
+        }
+      }
+    }
+  }
+  return all;
+}
+
+async function fetchGuidesForSearch(): Promise<SanityGuideForSearch[]> {
+  const query = `*[_type == "guide"] | order(publishedAt desc) {
+    _id,
+    title,
+    "slug": slug.current,
+    description,
+    "thumbnailUrl": thumbnail.asset->url,
+    category,
+    tags,
+    publishedAt,
+    readingTime,
+    isPremium
+  }`;
+  return sanity.fetch(query);
+}
+
+// ============================================================
+// SearchResult への変換
+// ============================================================
+
+function convertLessonToSearchResult(
+  lesson: SanityLessonForSearch
+): LessonSearchResult {
+  return {
+    id: lesson._id,
+    type: "lesson",
+    title: lesson.title,
+    description: lesson.description || "",
+    slug: lesson.slug?.current || "",
+    thumbnail: lesson.thumbnailUrl,
+    category: lesson.categoryTitle,
+    tags: lesson.tags,
+    isPremium: lesson.isPremium,
+    lessonCount: lesson.articleCount,
+    linkedRoadmaps: lesson.linkedRoadmaps,
+  };
+}
+
+function convertArticleToSearchResult(
+  article: SanityArticleForSearch
+): ArticleSearchResult {
+  let readingTime: number | undefined;
+  if (article.videoDuration) {
+    if (typeof article.videoDuration === "number") {
+      readingTime = Math.ceil(article.videoDuration / 60);
+    } else if (typeof article.videoDuration === "string") {
+      const parts = article.videoDuration.split(":").map(Number);
+      if (parts.length === 2) {
+        readingTime = parts[0] + Math.ceil(parts[1] / 60);
+      } else if (parts.length === 3) {
+        readingTime = parts[0] * 60 + parts[1] + Math.ceil(parts[2] / 60);
+      }
+    }
+  }
+  return {
+    id: article._id,
+    type: "article",
+    title: article.title,
+    description: article.excerpt || "",
+    slug: article.slug?.current || "",
+    thumbnail: article.thumbnailUrl,
+    tags: article.tags,
+    isPremium: article.isPremium,
+    parentLessonTitle: article.lessonTitle,
+    parentLessonSlug: article.lessonSlug,
+    readingTime,
+  };
+}
+
+function convertGuideToSearchResult(
+  guide: SanityGuideForSearch
+): GuideSearchResult {
+  return {
+    id: guide._id,
+    type: "guide",
+    title: guide.title,
+    description: guide.description || "",
+    slug: guide.slug || "",
+    thumbnail: guide.thumbnailUrl,
+    category: guide.category,
+    tags: guide.tags,
+    publishedAt: guide.publishedAt,
+    readingTime: guide.readingTime,
+    isPremium: guide.isPremium ?? false,
+  };
+}
+
+// ============================================================
+// GET ハンドラ
+// ============================================================
+
+export async function GET(_req: NextRequest) {
+  try {
+    const [lessons, articles, guides] = await Promise.all([
+      fetchLessonsForSearch(),
+      fetchArticlesForSearch(),
+      fetchGuidesForSearch(),
+    ]);
+
+    const results: SearchResult[] = [
+      ...lessons.map(convertLessonToSearchResult),
+      ...articles.map(convertArticleToSearchResult),
+      ...guides.map(convertGuideToSearchResult),
+    ];
+
+    return new Response(JSON.stringify(results), {
+      headers: {
+        "Content-Type": "application/json",
+        // Vercel CDN: 5分 fresh、10分 stale-while-revalidate
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+      },
+    });
+  } catch (error) {
+    console.error("[api/search] error:", error);
+    return new Response(
+      JSON.stringify({ error: "検索データの取得に失敗しました" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+}

--- a/src/app/dev/search-card/page.tsx
+++ b/src/app/dev/search-card/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React from "react";
+import HorizontalContentCard from "@/components/search/HorizontalContentCard";
+import { searchResultToCardProps } from "@/components/search/searchResultToCardProps";
+import { useSearchData } from "@/hooks/useSearch";
+import { groupSearchResults } from "@/types/search";
+import { Loader2 } from "lucide-react";
+
+/**
+ * /dev/search-card 結果カード ショーケース（実データ）
+ * Sanity から取得したレッスン / 記事 / ガイドを HorizontalContentCard で表示
+ */
+
+const MAX_PER_SECTION = 4;
+
+const Section: React.FC<{
+  title: string;
+  count: number;
+  children: React.ReactNode;
+}> = ({ title, count, children }) => (
+  <section className="mb-12">
+    <h2 className="text-lg font-bold text-gray-900 mb-3">
+      {title}{" "}
+      <span className="text-sm font-normal text-gray-500">({count}件)</span>
+    </h2>
+    <div className="space-y-3">{children}</div>
+  </section>
+);
+
+export default function SearchCardPreviewPage() {
+  const { data, isLoading, error } = useSearchData();
+
+  const grouped = data ? groupSearchResults(data) : null;
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="mb-8">
+        <p className="text-xs text-gray-500 mb-1">/dev/search-card</p>
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">
+          検索結果カード ショーケース（実データ）
+        </h1>
+        <p className="text-sm text-gray-600">
+          Sanity から取得したレッスン / 記事 / ガイドを各セクションに最大{" "}
+          {MAX_PER_SECTION} 件ずつ表示。
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
+          <span className="ml-3 text-gray-600">Sanity からデータ取得中...</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="text-center py-16 text-red-600">
+          取得に失敗しました：{(error as Error).message}
+        </div>
+      )}
+
+      {!isLoading && !error && grouped && (
+        <>
+          <Section
+            title="📚 レッスン"
+            count={Math.min(MAX_PER_SECTION, grouped.lesson.length)}
+          >
+            {grouped.lesson.slice(0, MAX_PER_SECTION).map((r) => {
+              const props = searchResultToCardProps(r);
+              return props ? (
+                <HorizontalContentCard key={r.id} {...props} />
+              ) : null;
+            })}
+            {grouped.lesson.length === 0 && (
+              <p className="text-sm text-gray-500">該当データなし</p>
+            )}
+          </Section>
+
+          <Section
+            title="📝 記事"
+            count={Math.min(MAX_PER_SECTION, grouped.article.length)}
+          >
+            {grouped.article.slice(0, MAX_PER_SECTION).map((r) => {
+              const props = searchResultToCardProps(r);
+              return props ? (
+                <HorizontalContentCard key={r.id} {...props} />
+              ) : null;
+            })}
+            {grouped.article.length === 0 && (
+              <p className="text-sm text-gray-500">該当データなし</p>
+            )}
+          </Section>
+
+          <Section
+            title="💡 ガイド"
+            count={Math.min(MAX_PER_SECTION, grouped.guide.length)}
+          >
+            {grouped.guide.slice(0, MAX_PER_SECTION).map((r) => {
+              const props = searchResultToCardProps(r);
+              return props ? (
+                <HorizontalContentCard key={r.id} {...props} />
+              ) : null;
+            })}
+            {grouped.guide.length === 0 && (
+              <p className="text-sm text-gray-500">該当データなし</p>
+            )}
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import {
 } from "next/font/google";
 import Script from "next/script";
 import { LayoutWrapper } from "@/components/layout/LayoutWrapper";
+import { QueryProvider } from "@/components/providers/QueryProvider";
 import { GoogleAnalytics } from "@/components/common/GoogleAnalytics";
 import "./globals.css";
 import "@/styles/blog.css";
@@ -120,7 +121,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} ${notoSansJp.variable} ${mplusRounded.variable} ${inter.variable} ${hind.variable} ${luckiestGuy.variable} ${lineSeedJP.variable} antialiased`}
       >
         <GoogleAnalytics />
-        <LayoutWrapper>{children}</LayoutWrapper>
+        <QueryProvider>
+          <LayoutWrapper>{children}</LayoutWrapper>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Suspense, useEffect, useMemo, useCallback } from "react";
+import React, { Suspense, useEffect, useMemo, useCallback, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import SearchBar from "@/components/search/SearchBar";
@@ -120,6 +120,33 @@ function SearchPageInner() {
   const sectionsToShow: SearchContentType[] =
     tab === "all" ? AVAILABLE_TYPES : tab === "ai" ? [] : [tab];
 
+  // ===== 各セクションの表示件数（最大 5 件 → さらに表示で +5）=====
+  const INITIAL_VISIBLE = 5;
+  const STEP = 5;
+  const [visibleCount, setVisibleCount] = useState<
+    Partial<Record<SearchContentType, number>>
+  >({});
+
+  // クエリ / tab 変更時にリセット
+  useEffect(() => {
+    setVisibleCount({});
+  }, [query, tab]);
+
+  const getVisibleCount = useCallback(
+    (type: SearchContentType) => visibleCount[type] ?? INITIAL_VISIBLE,
+    [visibleCount]
+  );
+
+  const showMore = useCallback(
+    (type: SearchContentType) => {
+      setVisibleCount((prev) => ({
+        ...prev,
+        [type]: (prev[type] ?? INITIAL_VISIBLE) + STEP,
+      }));
+    },
+    []
+  );
+
   return (
     <div className={cn("flex flex-col", tab === "ai" && "h-[calc(100vh-64px)]")}>
       {/* ヘッダー: 「探す」見出し位置は固定、検索バーだけアニメーションで開閉 */}
@@ -230,6 +257,9 @@ function SearchPageInner() {
               {sectionsToShow.map((type) => {
                 const sectionResults = groupedResults[type];
                 if (!sectionResults || sectionResults.length === 0) return null;
+                const visible = getVisibleCount(type);
+                const visibleResults = sectionResults.slice(0, visible);
+                const remaining = sectionResults.length - visible;
                 return (
                   <section key={type} className="mb-10">
                     <div className="flex items-center gap-2 mb-4">
@@ -242,13 +272,27 @@ function SearchPageInner() {
                       </span>
                     </div>
                     <div className="space-y-4">
-                      {sectionResults.map((result) => {
+                      {visibleResults.map((result) => {
                         const props = searchResultToCardProps(result);
                         return props ? (
                           <HorizontalContentCard key={result.id} {...props} />
                         ) : null;
                       })}
                     </div>
+                    {remaining > 0 && (
+                      <div className="mt-4 flex justify-center">
+                        <Button
+                          variant="outline"
+                          onClick={() => showMore(type)}
+                          className="gap-1.5"
+                        >
+                          さらに {Math.min(STEP, remaining)} 件表示
+                          <span className="text-xs text-gray-500">
+                            （残り {remaining} 件）
+                          </span>
+                        </Button>
+                      </div>
+                    )}
                   </section>
                 );
               })}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -11,8 +11,6 @@ import ChatInterface from "@/components/ai/ChatInterface";
 import {
   SearchContentType,
   groupSearchResults,
-  CONTENT_TYPE_LABELS,
-  CONTENT_TYPE_ICONS,
 } from "@/types/search";
 import { useSearch } from "@/hooks/useSearch";
 import {
@@ -21,29 +19,34 @@ import {
   Sparkles,
   MessageCircle,
 } from "lucide-react";
+import { MenuIcons } from "@/components/layout/Sidebar/icons";
+import type { SearchResult } from "@/types/search";
 import { trackSearch } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { runDiagnostics } from "@/lib/diagnostics";
 import { Button } from "@/components/ui/button";
 import { SLACK_QUESTIONS_URL } from "@/lib/external-links";
 
-const AVAILABLE_TYPES: SearchContentType[] = ["lesson", "article", "guide"];
+/** タブ別に useSearch へ渡す型のマッピング */
+const TAB_TO_TYPES: Record<Exclude<SearchTab, "ai" | "all">, SearchContentType[]> = {
+  lesson: ["lesson"],
+  guide: ["article", "guide"], // 記事はガイドに統合
+};
 
-/** URL クエリから現在の tab を解決（後方互換: mode=ai / types=lesson も拾う） */
+/** URL クエリから現在の tab を解決（後方互換: mode=ai / types=lesson / tab=article も拾う） */
 const resolveTab = (params: URLSearchParams | null): SearchTab => {
   if (!params) return "all";
   const tabParam = params.get("tab");
   if (tabParam) {
     if (tabParam === "ai" || tabParam === "all") return tabParam;
-    if ((AVAILABLE_TYPES as string[]).includes(tabParam)) {
-      return tabParam as SearchTab;
-    }
+    if (tabParam === "lesson") return "lesson";
+    // 記事は廃止 → ガイドに統合
+    if (tabParam === "article" || tabParam === "guide") return "guide";
   }
   if (params.get("mode") === "ai") return "ai";
   const firstType = params.get("types")?.split(",").filter(Boolean)[0];
-  if (firstType && (AVAILABLE_TYPES as string[]).includes(firstType)) {
-    return firstType as SearchTab;
-  }
+  if (firstType === "lesson") return "lesson";
+  if (firstType === "article" || firstType === "guide") return "guide";
   return "all";
 };
 
@@ -93,7 +96,7 @@ function SearchPageInner() {
   // tab → useSearch に渡す types
   const searchTypes: SearchContentType[] = useMemo(() => {
     if (tab === "ai" || tab === "all") return [];
-    return [tab];
+    return TAB_TO_TYPES[tab];
   }, [tab]);
 
   const { results, isLoading, error } = useSearch(
@@ -117,14 +120,42 @@ function SearchPageInner() {
     }
   }, [error]);
 
-  const sectionsToShow: SearchContentType[] =
-    tab === "all" ? AVAILABLE_TYPES : tab === "ai" ? [] : [tab];
+  // ===== 表示用セクション（記事はガイドに統合）=====
+  type SectionKey = "lesson" | "guide";
+  const sections: {
+    key: SectionKey;
+    label: string;
+    Icon: React.FC<{ size?: number; variant?: "Outline" | "Bold" | "Linear" | "Bulk" | "TwoTone" }>;
+    results: SearchResult[];
+  }[] = useMemo(() => {
+    const all = [
+      {
+        key: "lesson" as const,
+        label: "レッスン",
+        Icon: MenuIcons.lesson,
+        results: groupedResults.lesson as SearchResult[],
+      },
+      {
+        key: "guide" as const,
+        label: "ガイド",
+        Icon: MenuIcons.guide,
+        // 記事 + ガイドを統合
+        results: [
+          ...(groupedResults.guide as SearchResult[]),
+          ...(groupedResults.article as SearchResult[]),
+        ],
+      },
+    ];
+    if (tab === "all") return all;
+    if (tab === "ai") return [];
+    return all.filter((s) => s.key === tab);
+  }, [groupedResults, tab]);
 
   // ===== 各セクションの表示件数（最大 5 件 → さらに表示で +5）=====
   const INITIAL_VISIBLE = 5;
   const STEP = 5;
   const [visibleCount, setVisibleCount] = useState<
-    Partial<Record<SearchContentType, number>>
+    Partial<Record<SectionKey, number>>
   >({});
 
   // クエリ / tab 変更時にリセット
@@ -133,19 +164,16 @@ function SearchPageInner() {
   }, [query, tab]);
 
   const getVisibleCount = useCallback(
-    (type: SearchContentType) => visibleCount[type] ?? INITIAL_VISIBLE,
+    (key: SectionKey) => visibleCount[key] ?? INITIAL_VISIBLE,
     [visibleCount]
   );
 
-  const showMore = useCallback(
-    (type: SearchContentType) => {
-      setVisibleCount((prev) => ({
-        ...prev,
-        [type]: (prev[type] ?? INITIAL_VISIBLE) + STEP,
-      }));
-    },
-    []
-  );
+  const showMore = useCallback((key: SectionKey) => {
+    setVisibleCount((prev) => ({
+      ...prev,
+      [key]: (prev[key] ?? INITIAL_VISIBLE) + STEP,
+    }));
+  }, []);
 
   return (
     <div className={cn("flex flex-col", tab === "ai" && "h-[calc(100vh-64px)]")}>
@@ -254,18 +282,19 @@ function SearchPageInner() {
                 </div>
               )}
 
-              {sectionsToShow.map((type) => {
-                const sectionResults = groupedResults[type];
+              {sections.map((section) => {
+                const sectionResults = section.results;
                 if (!sectionResults || sectionResults.length === 0) return null;
-                const visible = getVisibleCount(type);
+                const visible = getVisibleCount(section.key);
                 const visibleResults = sectionResults.slice(0, visible);
                 const remaining = sectionResults.length - visible;
+                const { Icon } = section;
                 return (
-                  <section key={type} className="mb-10">
+                  <section key={section.key} className="mb-10">
                     <div className="flex items-center gap-2 mb-4">
-                      <span className="text-xl">{CONTENT_TYPE_ICONS[type]}</span>
+                      <Icon size={20} variant="Outline" />
                       <h2 className="text-lg font-bold text-gray-900">
-                        {CONTENT_TYPE_LABELS[type]}
+                        {section.label}
                       </h2>
                       <span className="text-sm text-gray-500">
                         ({sectionResults.length}件)
@@ -283,7 +312,7 @@ function SearchPageInner() {
                       <div className="mt-4 flex justify-center">
                         <Button
                           variant="outline"
-                          onClick={() => showMore(type)}
+                          onClick={() => showMore(section.key)}
                           className="gap-1.5"
                         >
                           さらに {Math.min(STEP, remaining)} 件表示

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -125,21 +125,18 @@ function SearchPageInner() {
   const sections: {
     key: SectionKey;
     label: string;
-    Icon: React.FC<{ size?: number; variant?: "Outline" | "Bold" | "Linear" | "Bulk" | "TwoTone" }>;
     results: SearchResult[];
   }[] = useMemo(() => {
     const all = [
       {
         key: "lesson" as const,
         label: "レッスン",
-        Icon: MenuIcons.lesson,
         results: groupedResults.lesson as SearchResult[],
       },
       {
         key: "guide" as const,
-        label: "ガイド",
-        Icon: MenuIcons.guide,
-        // 記事 + ガイドを統合
+        // 記事とガイドを混合表示しているので「コンテンツ」表記に
+        label: "コンテンツ",
         results: [
           ...(groupedResults.guide as SearchResult[]),
           ...(groupedResults.article as SearchResult[]),
@@ -150,6 +147,14 @@ function SearchPageInner() {
     if (tab === "ai") return [];
     return all.filter((s) => s.key === tab);
   }, [groupedResults, tab]);
+
+  /** 見出しに表示するアイコン（サイドナビと同一） */
+  const renderSectionIcon = (key: SectionKey) =>
+    key === "lesson" ? (
+      <MenuIcons.lesson size={20} color="#0d221d" variant="Outline" />
+    ) : (
+      <MenuIcons.guide size={20} color="#0d221d" variant="Outline" />
+    );
 
   // ===== 各セクションの表示件数（最大 5 件 → さらに表示で +5）=====
   const INITIAL_VISIBLE = 5;
@@ -288,11 +293,10 @@ function SearchPageInner() {
                 const visible = getVisibleCount(section.key);
                 const visibleResults = sectionResults.slice(0, visible);
                 const remaining = sectionResults.length - visible;
-                const { Icon } = section;
                 return (
                   <section key={section.key} className="mb-10">
                     <div className="flex items-center gap-2 mb-4">
-                      <Icon size={20} variant="Outline" />
+                      {renderSectionIcon(section.key)}
                       <h2 className="text-lg font-bold text-gray-900">
                         {section.label}
                       </h2>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import React, { Suspense, useEffect, useMemo, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { motion } from "framer-motion";
+import SearchBar from "@/components/search/SearchBar";
+import SearchTabs, { SearchTab } from "@/components/search/SearchTabs";
+import HorizontalContentCard from "@/components/search/HorizontalContentCard";
+import { searchResultToCardProps } from "@/components/search/searchResultToCardProps";
+import ChatInterface from "@/components/ai/ChatInterface";
+import {
+  SearchContentType,
+  groupSearchResults,
+  CONTENT_TYPE_LABELS,
+  CONTENT_TYPE_ICONS,
+} from "@/types/search";
+import { useSearch } from "@/hooks/useSearch";
+import {
+  Search as SearchIcon,
+  Loader2,
+  Sparkles,
+  MessageCircle,
+} from "lucide-react";
+import { trackSearch } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+import { runDiagnostics } from "@/lib/diagnostics";
+import { Button } from "@/components/ui/button";
+import { SLACK_QUESTIONS_URL } from "@/lib/external-links";
+
+const AVAILABLE_TYPES: SearchContentType[] = ["lesson", "article", "guide"];
+
+/** URL クエリから現在の tab を解決（後方互換: mode=ai / types=lesson も拾う） */
+const resolveTab = (params: URLSearchParams | null): SearchTab => {
+  if (!params) return "all";
+  const tabParam = params.get("tab");
+  if (tabParam) {
+    if (tabParam === "ai" || tabParam === "all") return tabParam;
+    if ((AVAILABLE_TYPES as string[]).includes(tabParam)) {
+      return tabParam as SearchTab;
+    }
+  }
+  if (params.get("mode") === "ai") return "ai";
+  const firstType = params.get("types")?.split(",").filter(Boolean)[0];
+  if (firstType && (AVAILABLE_TYPES as string[]).includes(firstType)) {
+    return firstType as SearchTab;
+  }
+  return "all";
+};
+
+function SearchPageInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tab = resolveTab(searchParams);
+  const queryParam = searchParams?.get("q") || "";
+
+  // URL を single source of truth に。内部 state は持たない。
+  const query = queryParam;
+
+  /** 現在の searchParams をベースに変更して /search?... に router.replace */
+  const updateParams = useCallback(
+    (mutate: (params: URLSearchParams) => void) => {
+      const next = new URLSearchParams(searchParams?.toString() || "");
+      mutate(next);
+      // 旧パラメータ（mode / types）を明示的に正規化のため落とす
+      next.delete("mode");
+      next.delete("types");
+      const qs = next.toString();
+      router.replace(qs ? `/search?${qs}` : "/search", { scroll: false });
+    },
+    [router, searchParams]
+  );
+
+  const setQuery = useCallback(
+    (newQuery: string) => {
+      updateParams((p) => {
+        if (newQuery) p.set("q", newQuery);
+        else p.delete("q");
+      });
+    },
+    [updateParams]
+  );
+
+  const setTab = useCallback(
+    (newTab: SearchTab) => {
+      updateParams((p) => {
+        if (newTab === "all") p.delete("tab");
+        else p.set("tab", newTab);
+      });
+    },
+    [updateParams]
+  );
+
+  // tab → useSearch に渡す types
+  const searchTypes: SearchContentType[] = useMemo(() => {
+    if (tab === "ai" || tab === "all") return [];
+    return [tab];
+  }, [tab]);
+
+  const { results, isLoading, error } = useSearch(
+    query,
+    searchTypes,
+    tab !== "ai"
+  );
+
+  const groupedResults = useMemo(() => groupSearchResults(results), [results]);
+
+  useEffect(() => {
+    if (query && !isLoading && tab !== "ai") {
+      trackSearch(query, results.length);
+    }
+  }, [query, isLoading, results.length, tab]);
+
+  useEffect(() => {
+    if (error) {
+      console.warn("[BONO] /search でエラーが発生しました。診断を実行します...");
+      runDiagnostics();
+    }
+  }, [error]);
+
+  const sectionsToShow: SearchContentType[] =
+    tab === "all" ? AVAILABLE_TYPES : tab === "ai" ? [] : [tab];
+
+  return (
+    <div className={cn("flex flex-col", tab === "ai" && "h-[calc(100vh-64px)]")}>
+      {/* ヘッダー: 「探す」見出し位置は固定、検索バーだけアニメーションで開閉 */}
+      <div className="px-4 pt-8 sm:pt-12">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">探す</h1>
+          <motion.div
+            initial={false}
+            animate={{
+              height: tab !== "ai" ? 64 : 0,
+              opacity: tab !== "ai" ? 1 : 0,
+              marginBottom: tab !== "ai" ? 24 : 0,
+            }}
+            transition={{ duration: 0.35, ease: [0.4, 0, 0.2, 1] }}
+            style={{ overflow: "hidden" }}
+            aria-hidden={tab === "ai"}
+          >
+            <SearchBar
+              key={queryParam}
+              defaultValue={query}
+              onSearch={(q) => setQuery(q)}
+              navigateOnSearch={false}
+              autoFocus={!query}
+              showSuggestions={false}
+            />
+          </motion.div>
+          <SearchTabs tab={tab} onTabChange={setTab} />
+        </div>
+      </div>
+
+      {tab !== "ai" && (
+        <div className="max-w-4xl mx-auto w-full px-4 py-8">
+          {isLoading && (
+            <div className="flex items-center justify-center py-16">
+              <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
+              <span className="ml-3 text-gray-600">検索中...</span>
+            </div>
+          )}
+
+          {error && (
+            <div className="text-center py-16">
+              <p className="text-red-600">
+                データの取得に失敗しました。再度お試しください。
+              </p>
+            </div>
+          )}
+
+          {!isLoading && !error && (
+            <>
+              <div className="mb-6">
+                <p className="text-sm text-gray-600">
+                  {query ? (
+                    <>
+                      「
+                      <span className="font-medium text-gray-900">{query}</span>
+                      」の検索結果：
+                      <span className="font-bold text-gray-900">
+                        {results.length}
+                      </span>
+                      件
+                    </>
+                  ) : (
+                    <>
+                      全コンテンツ：
+                      <span className="font-bold text-gray-900">
+                        {results.length}
+                      </span>
+                      件
+                    </>
+                  )}
+                </p>
+              </div>
+
+              {results.length === 0 && (
+                <div className="text-center py-16">
+                  <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-100 mb-4">
+                    <SearchIcon className="w-8 h-8 text-gray-400" />
+                  </div>
+                  <h2 className="text-xl font-bold text-gray-900 mb-2">
+                    検索結果が見つかりませんでした
+                  </h2>
+                  <p className="text-gray-600 mb-6">
+                    AI に聞くか、カイクンに直接質問してみましょう
+                  </p>
+                  <div className="flex flex-wrap items-center justify-center gap-3">
+                    <Button
+                      variant="secondary"
+                      onClick={() => setTab("ai")}
+                      className="gap-1.5"
+                    >
+                      <Sparkles className="w-4 h-4" />
+                      AIに聞く
+                    </Button>
+                    <Button variant="secondary" asChild className="gap-1.5">
+                      <a
+                        href={SLACK_QUESTIONS_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <MessageCircle className="w-4 h-4" />
+                        カイクンに質問する
+                      </a>
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {sectionsToShow.map((type) => {
+                const sectionResults = groupedResults[type];
+                if (!sectionResults || sectionResults.length === 0) return null;
+                return (
+                  <section key={type} className="mb-10">
+                    <div className="flex items-center gap-2 mb-4">
+                      <span className="text-xl">{CONTENT_TYPE_ICONS[type]}</span>
+                      <h2 className="text-lg font-bold text-gray-900">
+                        {CONTENT_TYPE_LABELS[type]}
+                      </h2>
+                      <span className="text-sm text-gray-500">
+                        ({sectionResults.length}件)
+                      </span>
+                    </div>
+                    <div className="space-y-4">
+                      {sectionResults.map((result) => {
+                        const props = searchResultToCardProps(result);
+                        return props ? (
+                          <HorizontalContentCard key={result.id} {...props} />
+                        ) : null;
+                      })}
+                    </div>
+                  </section>
+                );
+              })}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* AI チャット: 常時マウント、AI 以外のタブでは display:none で隠して履歴保持 */}
+      <div className={cn(tab === "ai" ? "flex-1 min-h-0" : "hidden")}>
+        <ChatInterface initialInput={query} />
+      </div>
+    </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
+        </div>
+      }
+    >
+      <SearchPageInner />
+    </Suspense>
+  );
+}

--- a/src/components/ai/AIAvatar.tsx
+++ b/src/components/ai/AIAvatar.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface AIAvatarProps {
+  className?: string;
+}
+
+/**
+ * AI アシスタントのアバター（48×48、グラデ + 👼 絵文字）
+ * ChatInterface 空状態のヘッダーと、ChatMessage の AI 応答アバターで共通使用
+ */
+export function AIAvatar({ className }: AIAvatarProps) {
+  return (
+    <div
+      className={cn(
+        "size-12 bg-linear-48 from-red-100 via-rose-200 to-violet-200 rounded-2xl inline-flex justify-center items-center flex-shrink-0",
+        className
+      )}
+    >
+      <div className="text-center justify-start text-gray-700 text-lg font-bold font-['Noto_Sans_JP'] leading-7">
+        👼
+      </div>
+    </div>
+  );
+}
+
+export default AIAvatar;

--- a/src/components/ai/ChatInterface.tsx
+++ b/src/components/ai/ChatInterface.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import React, { useRef, useEffect, useState, KeyboardEvent } from 'react';
+import { ArrowUp, RotateCcw, MessageCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useAIChat } from '@/hooks/useAIChat';
+import { SLACK_QUESTIONS_URL } from '@/lib/external-links';
+import ChatMessage from './ChatMessage';
+
+const SUGGESTED_QUESTIONS = [
+  'UIデザインを学び始めるには何から始めればいいですか？',
+  'ポートフォリオ制作で気をつけることは何ですか？',
+  'デザイナーに転職するためのロードマップを教えてください',
+  'Figmaの次に学ぶべきスキルは何ですか？',
+];
+
+interface ChatInterfaceProps {
+  /** 履歴なし・入力空のときに一度だけ入力欄へプリフィルされる初期値（自動送信はしない） */
+  initialInput?: string;
+}
+
+const ChatInterface = ({ initialInput }: ChatInterfaceProps) => {
+  const { messages, isLoading, error, sendMessage, clearMessages } = useAIChat();
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const emptyTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const bottomTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const isEmpty = messages.length === 0;
+  const activeTextareaRef = isEmpty ? emptyTextareaRef : bottomTextareaRef;
+
+  useEffect(() => {
+    if (!initialInput) return;
+    if (messages.length > 0) return;
+    if (input !== '') return;
+    setInput(initialInput);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialInput]);
+
+  // 新しいメッセージが来たら末尾にスクロール
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // textareaの高さを自動調整（active な側だけ動かす）
+  useEffect(() => {
+    const el = activeTextareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, [input, isEmpty, activeTextareaRef]);
+
+  const handleSubmit = () => {
+    if (!input.trim() || isLoading) return;
+    sendMessage(input);
+    setInput('');
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // IME 変換中の Enter は無視（日本語変換確定の Enter で誤送信されないように）
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+    // Cmd+Enter (Mac) / Ctrl+Enter (Win) で送信。素の Enter は改行
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const sendButtonClass = (active: boolean) =>
+    cn(
+      'flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-colors',
+      active
+        ? 'bg-black text-white hover:bg-black/90'
+        : 'bg-muted-foreground/15 text-muted-foreground cursor-not-allowed'
+    );
+
+  return (
+    <div className="flex flex-col h-full">
+      {isEmpty ? (
+        /* 空状態（Figma 17:1621）: 中央寄せのウェルカム + 大きい入力 + サジェスト2x2 */
+        <div className="flex-1 overflow-y-auto px-4 py-12">
+          <div className="max-w-2xl mx-auto flex flex-col gap-5">
+            {/* ヘッダー */}
+            <div className="text-center">
+              <h2 className="font-noto-sans-jp text-[20px] font-bold leading-[28px] text-[#020817]">
+                AI学習アシスタント
+              </h2>
+              <p className="pt-2 text-[14px] text-[#64748b] leading-[22.75px] tracking-tight">
+                悩みや疑問を自由に書いてください。
+                <br />
+                BONOのコンテンツをもとに最適な学習パスを提案します。
+              </p>
+            </div>
+
+            {/* 大きい入力フォーム（h-[173px] 相当、白ボックス全体がクリック範囲） */}
+            <label className="bg-white border border-gray-200 shadow-[0_1px_6px_rgba(0,0,0,0.08)] rounded-3xl px-[21px] py-[17px] min-h-[173px] flex flex-col justify-between cursor-text">
+              <textarea
+                ref={emptyTextareaRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="学習の悩みや疑問を書いてください..."
+                rows={1}
+                className="w-full bg-transparent text-[16px] text-foreground placeholder:text-[#64748b] resize-none outline-none leading-[1.625] min-h-[24px]"
+                disabled={isLoading}
+              />
+              <div className="flex items-center justify-end gap-2.5">
+                <span className="text-[11px] text-slate-500 tracking-wide">
+                  Cmd+Enterで送信
+                </span>
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={!input.trim() || isLoading}
+                  aria-label="送信"
+                  className={sendButtonClass(!!input.trim() && !isLoading)}
+                >
+                  <ArrowUp className="w-4 h-4" />
+                </button>
+              </div>
+            </label>
+
+            {/* サジェスト質問グリッド（2x2） */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {SUGGESTED_QUESTIONS.map((q) => (
+                <button
+                  key={q}
+                  onClick={() => {
+                    setInput(q);
+                    emptyTextareaRef.current?.focus();
+                  }}
+                  className="text-left text-[14px] text-[#020817] px-4 h-[46px] rounded-[12px] border border-[#e2e8f0] hover:bg-gray-50 transition-colors leading-5 truncate"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* メッセージエリア */}
+          <div className="flex-1 overflow-y-auto px-4 py-6">
+            <div className="max-w-2xl mx-auto space-y-6">
+              {messages.map((message) => (
+                <ChatMessage key={message.id} message={message} />
+              ))}
+              {error && (
+                <p className="text-sm text-destructive text-center">{error}</p>
+              )}
+              {!isLoading && (
+                <div className="pt-2 text-center">
+                  <a
+                    href={SLACK_QUESTIONS_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline transition-colors"
+                  >
+                    <MessageCircle className="w-3 h-3" />
+                    回答に満足できない？カイクンに質問する
+                  </a>
+                </div>
+              )}
+              <div ref={messagesEndRef} />
+            </div>
+          </div>
+
+          {/* 下部固定入力エリア（会話開始後のみ） */}
+          <div className="px-4 py-4">
+            <div className="max-w-2xl mx-auto">
+              <button
+                onClick={clearMessages}
+                className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3 ml-auto"
+              >
+                <RotateCcw className="w-3 h-3" />
+                会話をリセット
+              </button>
+
+              <label className="bg-white border border-gray-200 shadow-[0_4px_8px_rgba(0,0,0,0.06)] rounded-3xl px-6 pt-5 pb-2.5 flex flex-col cursor-text">
+                <textarea
+                  ref={bottomTextareaRef}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="学習の悩みや疑問を書いてください..."
+                  rows={1}
+                  className="w-full bg-transparent text-sm text-foreground placeholder:text-slate-500 resize-none outline-none leading-[1.625] min-h-[24px]"
+                  disabled={isLoading}
+                />
+                <div className="flex items-center justify-end gap-2.5 mt-1">
+                  <span className="text-[11px] text-slate-500 tracking-wide">
+                    Cmd+Enterで送信
+                  </span>
+                  <button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={!input.trim() || isLoading}
+                    aria-label="送信"
+                    className={sendButtonClass(!!input.trim() && !isLoading)}
+                  >
+                    <ArrowUp className="w-4 h-4" />
+                  </button>
+                </div>
+              </label>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ChatInterface;

--- a/src/components/ai/ChatInterface.tsx
+++ b/src/components/ai/ChatInterface.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import { useAIChat } from '@/hooks/useAIChat';
 import { SLACK_QUESTIONS_URL } from '@/lib/external-links';
 import ChatMessage from './ChatMessage';
+import { AIAvatar } from './AIAvatar';
 
 const SUGGESTED_QUESTIONS = [
   'UIデザインを学び始めるには何から始めればいいですか？',
@@ -79,16 +80,19 @@ const ChatInterface = ({ initialInput }: ChatInterfaceProps) => {
         /* 空状態（Figma 17:1621）: 中央寄せのウェルカム + 大きい入力 + サジェスト2x2 */
         <div className="flex-1 overflow-y-auto px-4 py-12">
           <div className="max-w-2xl mx-auto flex flex-col gap-5">
-            {/* ヘッダー */}
-            <div className="text-center">
-              <h2 className="font-noto-sans-jp text-[20px] font-bold leading-[28px] text-[#020817]">
-                AI学習アシスタント
-              </h2>
-              <p className="pt-2 text-[14px] text-[#64748b] leading-[22.75px] tracking-tight">
-                悩みや疑問を自由に書いてください。
-                <br />
-                BONOのコンテンツをもとに最適な学習パスを提案します。
-              </p>
+            {/* ヘッダー（AI アバター + 見出し） */}
+            <div className="flex flex-col items-center gap-3 text-center">
+              <AIAvatar />
+              <div>
+                <h2 className="font-noto-sans-jp text-[20px] font-bold leading-[28px] text-[#020817]">
+                  AI学習アシスタント
+                </h2>
+                <p className="pt-2 text-[14px] text-[#64748b] leading-[22.75px] tracking-tight">
+                  悩みや疑問を自由に書いてください。
+                  <br />
+                  BONOのコンテンツをもとに最適な学習パスを提案します。
+                </p>
+              </div>
             </div>
 
             {/* 大きい入力フォーム（h-[173px] 相当、白ボックス全体がクリック範囲） */}

--- a/src/components/ai/ChatMessage.tsx
+++ b/src/components/ai/ChatMessage.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { cn } from '@/lib/utils';
+import type { ChatMessage as ChatMessageType } from '@/hooks/useAIChat';
+
+interface ChatMessageProps {
+  message: ChatMessageType;
+}
+
+const ChatMessage = ({ message }: ChatMessageProps) => {
+  const isUser = message.role === 'user';
+
+  if (isUser) {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[80%] bg-foreground text-background rounded-2xl rounded-tr-sm px-4 py-3 text-sm leading-relaxed">
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-start gap-3">
+      {/* アバター */}
+      <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gradient-to-br from-violet-500 to-pink-500 flex items-center justify-center text-white text-[10px] font-bold mt-0.5">
+        AI
+      </div>
+
+      {/* メッセージ本文 */}
+      <div className="max-w-[85%] min-w-0">
+        <div
+          className={cn(
+            'text-sm leading-relaxed text-foreground',
+            '[&>*+*]:mt-3',
+            '[&_p]:leading-relaxed',
+            '[&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1',
+            '[&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-1',
+            '[&_li]:leading-relaxed',
+            '[&_strong]:font-bold',
+            '[&_a]:text-blue-600 [&_a]:underline [&_a]:underline-offset-2 [&_a]:hover:text-blue-700',
+            '[&_h2]:text-base [&_h2]:font-bold [&_h2]:mt-4',
+            '[&_h3]:text-sm [&_h3]:font-bold [&_h3]:mt-3',
+            '[&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-xs',
+          )}
+        >
+          {message.content ? (
+            <ReactMarkdown
+              components={{
+                a: ({ href, children }) => (
+                  <a href={href} target={href?.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer">
+                    {children}
+                  </a>
+                ),
+              }}
+            >
+              {message.content}
+            </ReactMarkdown>
+          ) : null}
+          {message.isStreaming && (
+            <span className="inline-block w-1.5 h-4 bg-foreground/40 rounded-sm animate-pulse ml-0.5 align-middle" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatMessage;

--- a/src/components/ai/ChatMessage.tsx
+++ b/src/components/ai/ChatMessage.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { cn } from '@/lib/utils';
 import type { ChatMessage as ChatMessageType } from '@/hooks/useAIChat';
+import { AIAvatar } from './AIAvatar';
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -24,10 +25,8 @@ const ChatMessage = ({ message }: ChatMessageProps) => {
 
   return (
     <div className="flex justify-start gap-3">
-      {/* アバター */}
-      <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gradient-to-br from-violet-500 to-pink-500 flex items-center justify-center text-white text-[10px] font-bold mt-0.5">
-        AI
-      </div>
+      {/* アバター（AIAvatar 共通コンポーネント） */}
+      <AIAvatar />
 
       {/* メッセージ本文 */}
       <div className="max-w-[85%] min-w-0">

--- a/src/components/guide/GuideCardMedia.tsx
+++ b/src/components/guide/GuideCardMedia.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils";
+import { getVideoInfo } from "@/lib/videoUtils";
+import { GuideCardImage } from "./GuideCardImage";
+import { GuideCardPlaceholder } from "./GuideCard";
+
+interface GuideCardMediaProps {
+  title: string;
+  thumbnail?: string;
+  videoUrl?: string;
+  className?: string;
+}
+
+/**
+ * ガイドカードのメディアブロック（aspect-video）
+ * 優先順位: サムネ画像 > ビデオのサムネ > プレースホルダ
+ * `/guide` 一覧と検索結果カードで共通利用
+ */
+export function GuideCardMedia({ title, thumbnail, videoUrl, className }: GuideCardMediaProps) {
+  const videoInfo = videoUrl ? getVideoInfo(videoUrl) : null;
+  const displayImage = thumbnail || videoInfo?.thumbnailUrl;
+
+  return (
+    <div className={cn("w-full aspect-video rounded-[19px] overflow-hidden bg-muted", className)}>
+      {displayImage ? (
+        <GuideCardImage src={displayImage} alt={title} />
+      ) : (
+        <GuideCardPlaceholder title={title} />
+      )}
+    </div>
+  );
+}
+
+export default GuideCardMedia;

--- a/src/components/layout/Sidebar/SidebarLogo.tsx
+++ b/src/components/layout/Sidebar/SidebarLogo.tsx
@@ -15,7 +15,7 @@ interface SidebarLogoProps {
 export function SidebarLogo({ className }: SidebarLogoProps) {
   return (
     <div className={cn("w-full", className)}>
-      <div className="w-full px-[28px] py-[33px]">
+      <div className="w-full px-[30px] py-[33px]">
         <Link href="/" className="flex items-center">
           <Logo width={81} height={24} />
         </Link>

--- a/src/components/layout/Sidebar/SidebarSearchBox.tsx
+++ b/src/components/layout/Sidebar/SidebarSearchBox.tsx
@@ -35,13 +35,13 @@ const SidebarSearchBox: React.FC<{ className?: string }> = ({ className }) => {
   return (
     <form
       onSubmit={handleSubmit}
-      className={cn("w-full px-[15px]", className)}
+      className={cn("w-full pl-[30px] pr-[15px]", className)}
       role="search"
     >
       <div
         className={cn(
-          "flex items-center gap-3 bg-white border border-gray-200 rounded-[12px]",
-          "px-[13px] py-[5px]",
+          "flex items-center gap-[12px] bg-white border border-gray-200 rounded-[12px]",
+          "px-[14px] py-[5px]",
           "focus-within:border-gray-900 transition-colors"
         )}
       >

--- a/src/components/layout/Sidebar/SidebarSearchBox.tsx
+++ b/src/components/layout/Sidebar/SidebarSearchBox.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * サイドバー専用のコンパクト検索ボックス
+ * Figma 19:1718 準拠（外側 px-[15px] でメニュー項目と幅揃え、内側 rounded-[12px] / px-[13px] py-[5px] / gap-3）
+ * submit で /search?q=... に遷移。すでに /search にいる場合は現在の tab パラメータを引き継ぐ
+ */
+const SidebarSearchBox: React.FC<{ className?: string }> = ({ className }) => {
+  const [query, setQuery] = useState("");
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    const next = new URLSearchParams();
+    next.set("q", trimmed);
+    // /search に既にいる場合のみ、tab を引き継ぐ（絞り込み状態の維持）
+    // ※ useSearchParams は static prerender で Suspense 要求するため、
+    //   submit 時のみ window.location.search から読む（クライアント実行のみ）
+    if (typeof window !== "undefined" && pathname === "/search") {
+      const currentTab = new URLSearchParams(window.location.search).get("tab");
+      if (currentTab) next.set("tab", currentTab);
+    }
+    router.push(`/search?${next.toString()}`);
+    setQuery("");
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn("w-full px-[15px]", className)}
+      role="search"
+    >
+      <div
+        className={cn(
+          "flex items-center gap-3 bg-white border border-gray-200 rounded-[12px]",
+          "px-[13px] py-[5px]",
+          "focus-within:border-gray-900 transition-colors"
+        )}
+      >
+        <Search
+          className="w-5 h-5 text-gray-400 flex-shrink-0 pointer-events-none"
+          strokeWidth={1.75}
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="探す"
+          aria-label="検索"
+          className={cn(
+            "w-full bg-transparent outline-none border-0",
+            "font-noto-sans-jp text-[13px] tracking-tight leading-[28px]",
+            "text-[#2F3037] placeholder:text-[#64748b]"
+          )}
+        />
+      </div>
+    </form>
+  );
+};
+
+export default SidebarSearchBox;

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -44,10 +44,11 @@ export function Sidebar({ className, user }: SidebarProps) {
       role="navigation"
       aria-label="メインナビゲーション"
     >
-      <SidebarLogo />
-
-      {/* 検索ボックス（ロゴ直下、Figma 19:1718） */}
-      <SidebarSearchBox />
+      {/* ロゴ + 検索（Figma 29:2352: ロゴ直下に検索バー、間隔 0px） */}
+      <div className="w-full flex flex-col items-start">
+        <SidebarLogo />
+        <SidebarSearchBox />
+      </div>
 
       <SidebarMenuGroup>
         {user && (

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import { SidebarProps } from "./types";
 import { cn } from "@/lib/utils";
 import { SidebarLogo } from "./SidebarLogo";
+import SidebarSearchBox from "./SidebarSearchBox";
 import { SidebarMenuGroup } from "./SidebarMenuGroup";
 import { SidebarMenuItem } from "./SidebarMenuItem";
 import { MenuIcons } from "./icons";
@@ -44,6 +45,9 @@ export function Sidebar({ className, user }: SidebarProps) {
       aria-label="メインナビゲーション"
     >
       <SidebarLogo />
+
+      {/* 検索ボックス（ロゴ直下、Figma 19:1718） */}
+      <SidebarSearchBox />
 
       <SidebarMenuGroup>
         {user && (

--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState, type ReactNode } from "react";
+
+/**
+ * React Query Provider（Client Component）
+ * - useSearch / useSearchData 等の useQuery を使うため
+ * - 各リクエストごとに QueryClient を 1 度だけ生成（HMR / SSR で再生成されないよう useState）
+ */
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 5 * 60 * 1000, // 5分
+            gcTime: 10 * 60 * 1000, // 10分
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/components/search/HorizontalContentCard.tsx
+++ b/src/components/search/HorizontalContentCard.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { Clock, Map } from "lucide-react";
+import { GradientLockIcon } from "@/components/ui/icon-lock-gradient";
+import { GuideCardMedia } from "@/components/guide/GuideCardMedia";
+
+export type HorizontalCardVariant = "lesson" | "article" | "guide";
+
+export interface HorizontalContentCardProps {
+  variant: HorizontalCardVariant;
+  href: string;
+  title: string;
+  thumbnailUrl?: string;
+  description?: string;
+
+  // variant 別メタ情報
+  lessonCount?: number; // lesson
+  category?: string; // lesson / guide
+  parentLessonTitle?: string; // article
+  readingTime?: number; // article（分）
+  author?: { name: string; avatarUrl?: string }; // guide
+  publishedDate?: string; // guide
+  videoUrl?: string; // guide（あれば iframe 優先）
+  linkedRoadmaps?: { slug: string; title: string; shortTitle?: string }[]; // lesson
+
+  isPremium?: boolean;
+  className?: string;
+}
+
+/** `2026/5/8` 形式で整形（ISO or 既に整形済の文字列を許容） */
+const formatPublishedDate = (date?: string): string => {
+  if (!date) return "";
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return date;
+  return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
+};
+
+// ============================================================
+// Lesson 横版：main の LessonCardHorizontal をベース + ロードマップタグ
+// ============================================================
+const LessonRow: React.FC<HorizontalContentCardProps & { showLock: boolean }> = ({
+  href,
+  title,
+  thumbnailUrl,
+  description,
+  category,
+  linkedRoadmaps,
+  showLock,
+  className,
+}) => {
+  const hasRoadmap = !!linkedRoadmaps && linkedRoadmaps.length > 0;
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group bg-white flex items-stretch gap-4 p-3 sm:p-4 rounded-[16px] sm:rounded-[20px]",
+        "shadow-[0px_1px_8px_0px_rgba(0,0,0,0.08)]",
+        "transform transition-all duration-200",
+        "hover:-translate-y-0.5 hover:shadow-[0px_4px_18px_0px_rgba(0,0,0,0.16)]",
+        "w-full text-[#0d221d]",
+        className
+      )}
+    >
+      {/* サムネイル（縦長 2:3、本表紙風） */}
+      <div className="flex-shrink-0 w-[180px] sm:w-[240px] aspect-video p-3 rounded-xl bg-[#F5F5F5] flex items-center justify-center">
+        {thumbnailUrl ? (
+          <div className="h-full aspect-[2/3] rounded-[4px] shadow-[0px_0px_16px_0px_rgba(0,0,0,0.12)] overflow-hidden bg-white">
+            <img
+              src={thumbnailUrl}
+              alt={`${title}のサムネイル`}
+              className="w-full h-full object-cover"
+              loading="lazy"
+            />
+          </div>
+        ) : (
+          <div className="h-full aspect-[2/3] rounded-[4px] bg-gray-200" />
+        )}
+      </div>
+
+      {/* テキストエリア */}
+      <div className="flex-1 min-w-0 flex flex-col gap-1 justify-center">
+        {category && (
+          <span className="inline-flex items-center self-start px-2 py-0.5 border border-black rounded-[30px]">
+            <span className="font-noto-sans-jp text-[10px] sm:text-[11px] font-medium text-[#0d221d] leading-[10px]">
+              {category}
+            </span>
+          </span>
+        )}
+        <h3 className="font-rounded-mplus-bold text-base font-bold text-[#0d221d] leading-[1.4] line-clamp-2">
+          {showLock && (
+            <GradientLockIcon
+              size={14}
+              className="inline-block align-middle mr-1 -mt-0.5"
+            />
+          )}
+          {title}
+        </h3>
+        {description && (
+          <p className="font-noto-sans-jp text-[10px] sm:text-[11px] font-medium text-[var(--text-muted)] leading-[1.5] line-clamp-2">
+            {description}
+          </p>
+        )}
+        {hasRoadmap && (
+          <div className="flex flex-wrap items-center gap-1 mt-1">
+            {linkedRoadmaps!.map((roadmap) => (
+              <span
+                key={roadmap.slug}
+                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-[rgba(13,34,29,0.06)] rounded-md text-[9px] sm:text-[10px] font-medium text-[rgba(13,34,29,0.56)]"
+              >
+                <Map className="w-2 h-2 sm:w-2.5 sm:h-2.5" />
+                {roadmap.shortTitle || roadmap.title}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+};
+
+// ============================================================
+// Guide 横版：本番 GuideCard と同じ要素（カテゴリ上、日付下） + 横レイアウト
+// ============================================================
+const GuideRow: React.FC<HorizontalContentCardProps & { showLock: boolean }> = ({
+  href,
+  title,
+  thumbnailUrl,
+  videoUrl,
+  description,
+  category,
+  author,
+  publishedDate,
+  showLock,
+  className,
+}) => {
+  const formattedDate = formatPublishedDate(publishedDate);
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group bg-white flex items-stretch gap-4 sm:gap-5 p-3 sm:p-4 rounded-2xl",
+        "shadow-[0px_1px_8px_0px_rgba(0,0,0,0.06)]",
+        "hover:-translate-y-0.5 hover:shadow-[0px_4px_16px_0px_rgba(0,0,0,0.10)]",
+        "transition-all duration-200",
+        className
+      )}
+    >
+      {/* メディア（GuideCardMedia と同じ。レッスン・記事と同じサムネ幅で統一） */}
+      <div className="flex-shrink-0 w-[180px] sm:w-[240px]">
+        <GuideCardMedia title={title} videoUrl={videoUrl} thumbnail={thumbnailUrl} />
+      </div>
+
+      {/* テキストエリア */}
+      <div className="flex-1 min-w-0 flex flex-col gap-2 justify-center py-1">
+        {/* カテゴリラベル（タイトル上のサブテキスト） */}
+        {category && (
+          <span className="text-[13px] text-text-muted">{category}</span>
+        )}
+
+        <h3 className="text-base font-bold text-foreground leading-snug line-clamp-2 text-balance group-hover:opacity-70 transition-opacity duration-200">
+          {showLock && (
+            <GradientLockIcon
+              size={14}
+              className="inline-block align-middle mr-1 -mt-0.5"
+            />
+          )}
+          {title}
+        </h3>
+
+        {description && (
+          <p className="text-sm text-text-muted leading-relaxed line-clamp-2">
+            {description}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between mt-1">
+          {author && (
+            <div className="flex items-center gap-1.5">
+              {author.avatarUrl ? (
+                <img
+                  src={author.avatarUrl}
+                  alt=""
+                  className="w-5 h-5 rounded-full object-cover"
+                />
+              ) : (
+                <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center">
+                  <span className="text-[8px] font-bold text-muted-foreground">
+                    {author.name.charAt(0)}
+                  </span>
+                </div>
+              )}
+              <span className="text-[13px] font-medium text-foreground">
+                {author.name}
+              </span>
+            </div>
+          )}
+          {formattedDate && (
+            <span className="text-[13px] text-text-muted">{formattedDate}</span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+// ============================================================
+// Article 横版：BookmarkListItem の流れを汲んだコンパクト横長
+// ============================================================
+const ArticleRow: React.FC<HorizontalContentCardProps & { showLock: boolean }> = ({
+  href,
+  title,
+  thumbnailUrl,
+  description,
+  parentLessonTitle,
+  readingTime,
+  showLock,
+  className,
+}) => {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group bg-white flex items-stretch gap-4 p-3 sm:p-4 rounded-2xl",
+        "shadow-[0px_1px_8px_0px_rgba(0,0,0,0.06)]",
+        "hover:-translate-y-0.5 hover:shadow-[0px_4px_16px_0px_rgba(0,0,0,0.10)]",
+        "transition-all duration-200",
+        className
+      )}
+    >
+      {/* サムネ（横長コンパクト） */}
+      <div className="flex-shrink-0 w-[180px] sm:w-[240px] aspect-video rounded-xl overflow-hidden bg-[#F5F5F5]">
+        {thumbnailUrl ? (
+          <img
+            src={thumbnailUrl}
+            alt={title}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full" />
+        )}
+      </div>
+
+      {/* テキスト */}
+      <div className="flex-1 min-w-0 flex flex-col gap-1 justify-center">
+        <h3 className="font-rounded-mplus text-base font-bold text-black leading-snug line-clamp-2">
+          {showLock && (
+            <GradientLockIcon
+              size={14}
+              className="inline-block align-middle mr-1 -mt-0.5"
+            />
+          )}
+          {title}
+        </h3>
+        {parentLessonTitle && (
+          <p className="text-xs text-[#4B5563] truncate">
+            by {parentLessonTitle}
+            {typeof readingTime === "number" && (
+              <span className="ml-2 inline-flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {readingTime}分
+              </span>
+            )}
+          </p>
+        )}
+        {description && (
+          <p className="text-xs text-gray-500 leading-relaxed line-clamp-2 mt-0.5">
+            {description}
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+};
+
+// ============================================================
+// ディスパッチャー
+// ============================================================
+const HorizontalContentCard: React.FC<HorizontalContentCardProps> = (props) => {
+  // TODO: サブスクリプション判定を Next.js 版の SubscriptionContext / canAccessContent に接続
+  //       現状は一律 ロック非表示（後でフェーズ 11 で対応）
+  const isLocked = false;
+  const showLock = isLocked && props.variant !== "lesson";
+
+  switch (props.variant) {
+    case "lesson":
+      return <LessonRow {...props} showLock={showLock} />;
+    case "guide":
+      return <GuideRow {...props} showLock={showLock} />;
+    case "article":
+    default:
+      return <ArticleRow {...props} showLock={showLock} />;
+  }
+};
+
+export default HorizontalContentCard;

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { Search, X, ArrowRight, Loader2 } from "lucide-react";
+import {
+  SearchResult,
+  CONTENT_TYPE_ICONS,
+  CONTENT_TYPE_LABELS,
+  CONTENT_TYPE_COLORS,
+} from "@/types/search";
+import { useSearchData, searchFromCache } from "@/hooks/useSearch";
+
+interface SearchBarProps {
+  className?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  onSearch?: (query: string) => void;
+  defaultValue?: string;
+  /** 検索ページに遷移するか、コールバックのみ呼ぶか */
+  navigateOnSearch?: boolean;
+  /** オートコンプリートを有効にするか */
+  showSuggestions?: boolean;
+}
+
+/**
+ * 検索バーコンポーネント（オートコンプリート機能付き）
+ * Sanityのデータをリアルタイムで検索
+ */
+const SearchBar: React.FC<SearchBarProps> = ({
+  className,
+  placeholder = "レッスン、記事、ガイドを検索...",
+  autoFocus = false,
+  onSearch,
+  defaultValue = "",
+  navigateOnSearch = true,
+  showSuggestions = true,
+}) => {
+  const [query, setQuery] = useState(defaultValue);
+  const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Sanityから検索データを取得
+  const { data: searchData, isLoading: isLoadingData } = useSearchData();
+
+  // デバウンス用タイマー
+  const debounceRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+  // 検索候補を取得
+  useEffect(() => {
+    if (!showSuggestions || !searchData) return;
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (query.trim().length < 1) {
+      setSuggestions([]);
+      setIsOpen(false);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      const results = searchFromCache(searchData, query, 8);
+      setSuggestions(results);
+      setIsOpen(results.length > 0);
+      setSelectedIndex(-1);
+    }, 150); // 150msデバウンス
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [query, showSuggestions, searchData]);
+
+  // 外部クリックでドロップダウンを閉じる
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // 検索実行
+  const executeSearch = useCallback(
+    (searchQuery: string) => {
+      const trimmedQuery = searchQuery.trim();
+      if (!trimmedQuery) return;
+
+      setIsOpen(false);
+
+      if (onSearch) {
+        onSearch(trimmedQuery);
+      }
+
+      if (navigateOnSearch) {
+        router.push(`/search?q=${encodeURIComponent(trimmedQuery)}`);
+      }
+    },
+    [onSearch, router, navigateOnSearch]
+  );
+
+  // 候補選択
+  const selectSuggestion = useCallback(
+    (result: SearchResult) => {
+      setQuery(result.title);
+      setIsOpen(false);
+
+      // 直接そのコンテンツへ遷移
+      let path = "";
+      switch (result.type) {
+        case "lesson":
+          path = `/lessons/${result.slug}`;
+          break;
+        case "article":
+          path = `/articles/${result.slug}`;
+          break;
+        case "guide":
+          path = `/knowledge/${result.slug}`;
+          break;
+        case "roadmap":
+          path = `/roadmaps/${result.slug}`;
+          break;
+      }
+      router.push(path);
+    },
+    [router]
+  );
+
+  // フォーム送信
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (selectedIndex >= 0 && suggestions[selectedIndex]) {
+        selectSuggestion(suggestions[selectedIndex]);
+      } else {
+        executeSearch(query);
+      }
+    },
+    [query, selectedIndex, suggestions, executeSearch, selectSuggestion]
+  );
+
+  // キーボードナビゲーション
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isOpen || suggestions.length === 0) return;
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev < suggestions.length - 1 ? prev + 1 : prev
+          );
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
+          break;
+        case "Escape":
+          setIsOpen(false);
+          setSelectedIndex(-1);
+          break;
+      }
+    },
+    [isOpen, suggestions.length]
+  );
+
+  // クリア
+  const handleClear = useCallback(() => {
+    setQuery("");
+    setSuggestions([]);
+    setIsOpen(false);
+    if (onSearch) {
+      onSearch("");
+    }
+    inputRef.current?.focus();
+  }, [onSearch]);
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)}>
+      <form onSubmit={handleSubmit}>
+        <div className="relative">
+          {/* 検索アイコン / ローディング */}
+          <div className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400">
+            {isLoadingData && showSuggestions ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <Search className="w-5 h-5" />
+            )}
+          </div>
+
+          {/* 入力フィールド */}
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => {
+              if (suggestions.length > 0) setIsOpen(true);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+            autoComplete="off"
+            className={cn(
+              "w-full pl-12 pr-12 py-3 sm:py-4",
+              "text-base sm:text-lg",
+              "bg-white border border-gray-200 rounded-2xl",
+              "focus:outline-none focus:border-gray-900 focus:ring-0",
+              "placeholder:text-gray-400",
+              "transition-colors duration-200",
+              isOpen && "rounded-b-none border-b-0"
+            )}
+          />
+
+          {/* クリアボタン */}
+          {query && (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          )}
+        </div>
+      </form>
+
+      {/* オートコンプリートドロップダウン */}
+      {isOpen && suggestions.length > 0 && (
+        <div className="absolute z-50 w-full bg-white border border-t-0 border-gray-200 rounded-b-2xl shadow-lg overflow-hidden">
+          <ul className="py-2">
+            {suggestions.map((result, index) => {
+              const colors = CONTENT_TYPE_COLORS[result.type];
+              const icon = CONTENT_TYPE_ICONS[result.type];
+              const label = CONTENT_TYPE_LABELS[result.type];
+
+              return (
+                <li key={result.id}>
+                  <button
+                    type="button"
+                    onClick={() => selectSuggestion(result)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={cn(
+                      "w-full px-4 py-3 flex items-center gap-3 text-left transition-colors",
+                      selectedIndex === index
+                        ? "bg-gray-50"
+                        : "hover:bg-gray-50"
+                    )}
+                  >
+                    {/* アイコン */}
+                    <div
+                      className={cn(
+                        "flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center",
+                        colors.bg
+                      )}
+                    >
+                      <span className="text-lg">{icon}</span>
+                    </div>
+
+                    {/* コンテンツ */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={cn(
+                            "text-xs px-1.5 py-0.5 rounded",
+                            colors.bg,
+                            colors.text
+                          )}
+                        >
+                          {label}
+                        </span>
+                      </div>
+                      <p className="text-sm font-medium text-gray-900 truncate mt-0.5">
+                        {result.title}
+                      </p>
+                      {result.description && (
+                        <p className="text-xs text-gray-500 truncate">
+                          {result.description}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* 矢印 */}
+                    <ArrowRight className="flex-shrink-0 w-4 h-4 text-gray-400" />
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          {/* 全結果を見るリンク */}
+          <div className="border-t border-gray-100 px-4 py-3">
+            <button
+              type="button"
+              onClick={() => executeSearch(query)}
+              className="w-full flex items-center justify-center gap-2 text-sm text-blue-600 hover:text-blue-700 font-medium"
+            >
+              <Search className="w-4 h-4" />「{query}」で検索
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 検索ボタン（モバイル用・ドロップダウンが閉じている時のみ） */}
+      {!isOpen && (
+        <button
+          type="button"
+          onClick={() => executeSearch(query)}
+          className={cn(
+            "mt-3 w-full py-3 px-6",
+            "bg-gray-900 text-white font-medium rounded-xl",
+            "hover:bg-gray-800 transition-colors",
+            "sm:hidden"
+          )}
+        >
+          検索
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/components/search/SearchTabs.tsx
+++ b/src/components/search/SearchTabs.tsx
@@ -33,7 +33,7 @@ const SearchTabs: React.FC<SearchTabsProps> = ({
     },
     {
       id: "guide",
-      label: "ガイド",
+      label: "コンテンツ",
       icon: <MenuIcons.guide size={14} variant="Outline" />,
     },
   ];

--- a/src/components/search/SearchTabs.tsx
+++ b/src/components/search/SearchTabs.tsx
@@ -3,25 +3,20 @@
 import React from "react";
 import { cn } from "@/lib/utils";
 import { Sparkles } from "lucide-react";
-import {
-  SearchContentType,
-  CONTENT_TYPE_LABELS,
-  CONTENT_TYPE_ICONS,
-} from "@/types/search";
+import { MenuIcons } from "@/components/layout/Sidebar/icons";
 
-export type SearchTab = "ai" | "all" | SearchContentType;
+/** タブの種類 — 記事はガイドに統合済 */
+export type SearchTab = "ai" | "all" | "lesson" | "guide";
 
 interface SearchTabsProps {
   tab: SearchTab;
   onTabChange: (tab: SearchTab) => void;
-  availableTypes?: SearchContentType[];
   className?: string;
 }
 
 const SearchTabs: React.FC<SearchTabsProps> = ({
   tab,
   onTabChange,
-  availableTypes = ["lesson", "article", "guide"],
   className,
 }) => {
   const tabs: { id: SearchTab; label: string; icon?: React.ReactNode }[] = [
@@ -31,15 +26,16 @@ const SearchTabs: React.FC<SearchTabsProps> = ({
       icon: <Sparkles className="w-3.5 h-3.5" />,
     },
     { id: "all", label: "すべて" },
-    ...availableTypes.map((type) => ({
-      id: type as SearchTab,
-      label: CONTENT_TYPE_LABELS[type],
-      icon: (
-        <span className="text-base leading-none">
-          {CONTENT_TYPE_ICONS[type]}
-        </span>
-      ),
-    })),
+    {
+      id: "lesson",
+      label: "レッスン",
+      icon: <MenuIcons.lesson size={14} variant="Outline" />,
+    },
+    {
+      id: "guide",
+      label: "ガイド",
+      icon: <MenuIcons.guide size={14} variant="Outline" />,
+    },
   ];
 
   return (

--- a/src/components/search/SearchTabs.tsx
+++ b/src/components/search/SearchTabs.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import { Sparkles } from "lucide-react";
+import {
+  SearchContentType,
+  CONTENT_TYPE_LABELS,
+  CONTENT_TYPE_ICONS,
+} from "@/types/search";
+
+export type SearchTab = "ai" | "all" | SearchContentType;
+
+interface SearchTabsProps {
+  tab: SearchTab;
+  onTabChange: (tab: SearchTab) => void;
+  availableTypes?: SearchContentType[];
+  className?: string;
+}
+
+const SearchTabs: React.FC<SearchTabsProps> = ({
+  tab,
+  onTabChange,
+  availableTypes = ["lesson", "article", "guide"],
+  className,
+}) => {
+  const tabs: { id: SearchTab; label: string; icon?: React.ReactNode }[] = [
+    {
+      id: "ai",
+      label: "AIに聞く",
+      icon: <Sparkles className="w-3.5 h-3.5" />,
+    },
+    { id: "all", label: "すべて" },
+    ...availableTypes.map((type) => ({
+      id: type as SearchTab,
+      label: CONTENT_TYPE_LABELS[type],
+      icon: (
+        <span className="text-base leading-none">
+          {CONTENT_TYPE_ICONS[type]}
+        </span>
+      ),
+    })),
+  ];
+
+  return (
+    <div
+      role="tablist"
+      className={cn(
+        "flex items-center gap-1 border-b border-gray-200",
+        className
+      )}
+    >
+      {tabs.map((t) => {
+        const isActive = tab === t.id;
+        return (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onTabChange(t.id)}
+            className={cn(
+              "relative inline-flex items-center gap-1.5 px-4 pt-2 pb-[9px] text-sm font-medium tracking-tight transition-colors",
+              isActive
+                ? "text-black"
+                : "text-gray-500 hover:text-gray-900"
+            )}
+          >
+            {t.icon}
+            {t.label}
+            {isActive && (
+              <span className="absolute left-0 right-0 -bottom-px h-px bg-black" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SearchTabs;

--- a/src/components/search/searchResultToCardProps.ts
+++ b/src/components/search/searchResultToCardProps.ts
@@ -1,0 +1,77 @@
+import {
+  SearchResult,
+  isLessonResult,
+  isArticleResult,
+  isGuideResult,
+} from "@/types/search";
+import type {
+  HorizontalContentCardProps,
+  HorizontalCardVariant,
+} from "./HorizontalContentCard";
+
+/** SearchResult から HorizontalContentCard の href を解決 */
+export const resolveSearchResultHref = (r: SearchResult): string => {
+  switch (r.type) {
+    case "lesson":
+      return `/lessons/${r.slug}`;
+    case "article":
+      if (isArticleResult(r) && r.parentLessonSlug) {
+        return `/lessons/${r.parentLessonSlug}/${r.slug}`;
+      }
+      return `/articles/${r.slug}`;
+    case "guide":
+      return `/guide/${r.slug}`;
+    case "roadmap":
+      return `/roadmaps/${r.slug}`;
+    default:
+      return "#";
+  }
+};
+
+/**
+ * SearchResult を HorizontalContentCard の props に変換
+ * roadmap は HorizontalContentCard が受けないので null を返す
+ */
+export const searchResultToCardProps = (
+  r: SearchResult
+): HorizontalContentCardProps | null => {
+  if (r.type === "roadmap") return null;
+
+  const variant = r.type as HorizontalCardVariant;
+  const base = {
+    variant,
+    href: resolveSearchResultHref(r),
+    title: r.title,
+    description: r.description,
+    thumbnailUrl: r.thumbnail,
+    isPremium: r.isPremium,
+  } as const;
+
+  if (isLessonResult(r)) {
+    return {
+      ...base,
+      variant: "lesson",
+      category: r.category,
+      lessonCount: r.lessonCount,
+      linkedRoadmaps: r.linkedRoadmaps,
+    };
+  }
+  if (isArticleResult(r)) {
+    return {
+      ...base,
+      variant: "article",
+      parentLessonTitle: r.parentLessonTitle,
+      readingTime: r.readingTime,
+    };
+  }
+  if (isGuideResult(r)) {
+    return {
+      ...base,
+      variant: "guide",
+      author: r.author ? { name: r.author } : undefined,
+      publishedDate: r.publishedAt,
+      category: r.category,
+    };
+  }
+  return null;
+};

--- a/src/hooks/useAIChat.ts
+++ b/src/hooks/useAIChat.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useCallback, useRef } from 'react';
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  isStreaming?: boolean;
+}
+
+export function useAIChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const sendMessage = useCallback(async (userInput: string) => {
+    if (!userInput.trim() || isLoading) return;
+
+    setError(null);
+
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: userInput.trim(),
+    };
+
+    const assistantMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'assistant',
+      content: '',
+      isStreaming: true,
+    };
+
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
+    setIsLoading(true);
+
+    // APIに送るメッセージ履歴（新しいユーザーメッセージを含む）
+    const historyForApi = [
+      ...messages.map((m) => ({ role: m.role, content: m.content })),
+      { role: 'user' as const, content: userInput.trim() },
+    ];
+
+    abortRef.current = new AbortController();
+
+    try {
+      const response = await fetch('/api/ai-chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: historyForApi }),
+        signal: abortRef.current.signal,
+      });
+
+      if (!response.ok) {
+        const status = response.status;
+        console.error(`[BONO AI] /api/ai-chat エラー status=${status}`);
+        if (status === 500) {
+          console.error('[BONO AI] 原因候補: GROQ_API_KEY が Vercel のプレビュー環境に設定されていない');
+          console.error('[BONO AI] 確認: Vercel Dashboard → Settings → Environment Variables → GROQ_API_KEY の "Preview" チェックを確認');
+        } else if (status === 404) {
+          console.error('[BONO AI] /api/ai-chat が見つかりません。Vercel にデプロイされていない可能性があります');
+        } else if (status === 405) {
+          console.error('[BONO AI] Method Not Allowed — POST 以外のリクエストが送られています');
+        }
+        throw new Error(`APIエラー (${status})`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error('ストリームの読み取りに失敗しました');
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6).trim();
+          if (data === '[DONE]') break;
+
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.text) {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantMessage.id
+                    ? { ...m, content: m.content + parsed.text }
+                    : m
+                )
+              );
+            }
+          } catch {
+            // parse error - skip
+          }
+        }
+      }
+    } catch (err: any) {
+      if (err.name === 'AbortError') return;
+      console.error('[BONO AI] 送信エラー:', err);
+      setError(`回答の取得に失敗しました（${err.message}）。コンソールを確認してください。`);
+      setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
+    } finally {
+      // ストリーミング完了
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantMessage.id ? { ...m, isStreaming: false } : m
+        )
+      );
+      setIsLoading(false);
+    }
+  }, [messages, isLoading]);
+
+  const clearMessages = useCallback(() => {
+    setMessages([]);
+    setError(null);
+  }, []);
+
+  return { messages, isLoading, error, sendMessage, clearMessages };
+}

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,273 +1,30 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
-import { client } from "@/lib/sanity";
 import {
   SearchResult,
-  LessonSearchResult,
-  ArticleSearchResult,
-  GuideSearchResult,
   SearchContentType,
+  CONTENT_TYPE_LABELS,
+  CONTENT_TYPE_ICONS,
 } from "@/types/search";
 
-// ============================================
-// Sanityデータ型
-// ============================================
+// ============================================================
+// 検索データ取得（クライアントは /api/search を fetch するだけ）
+// - CORS 回避（同一オリジン）
+// - サーバー側で useCdn:true + Vercel s-maxage キャッシュで高速化
+// ============================================================
 
-interface SanityLessonForSearch {
-  _id: string;
-  title: string;
-  slug: { current: string };
-  description?: string;
-  thumbnailUrl?: string;
-  category?: string;
-  categoryTitle?: string;
-  tags?: string[];
-  isPremium?: boolean;
-  articleCount: number;
-}
-
-interface SanityArticleForSearch {
-  _id: string;
-  title: string;
-  slug: { current: string };
-  excerpt?: string;
-  thumbnailUrl?: string;
-  tags?: string[];
-  isPremium?: boolean;
-  videoDuration?: string | number;
-  lessonTitle?: string;
-  lessonSlug?: string;
-}
-
-interface SanityGuideForSearch {
-  _id: string;
-  title: string;
-  slug: string; // クエリで slug.current に解決済み
-  description?: string;
-  thumbnailUrl?: string;
-  category?: string;
-  tags?: string[];
-  publishedAt?: string;
-  readingTime?: string;
-  isPremium?: boolean;
-}
-
-// ============================================
-// Sanityクエリ
-// ============================================
-
-/**
- * 検索用のレッスンデータを取得
- */
-async function fetchLessonsForSearch(): Promise<SanityLessonForSearch[]> {
-  try {
-    // Lessons.tsx と同じ解決順序で thumbnail URL を coalesce
-    // 1) iconImageUrl, 2) iconImage の asset URL, 3) thumbnailUrl, 4) thumbnail の asset URL
-    const query = `*[_type == "lesson"] | order(_createdAt desc) {
-      _id,
-      title,
-      slug,
-      description,
-      "thumbnailUrl": coalesce(
-        iconImageUrl,
-        iconImage.asset->url,
-        thumbnailUrl,
-        thumbnail.asset->url
-      ),
-      "categoryTitle": category->title,
-      tags,
-      isPremium,
-      "articleCount": count(quests[]->articles[]),
-      "linkedRoadmaps": *[_type == "roadmap" && references(^._id)] {
-        "slug": slug.current,
-        title,
-        shortTitle
-      }
-    }`;
-    return client().fetch(query);
-  } catch (error) {
-    console.error('検索用レッスンデータの取得に失敗:', error);
-    throw new Error('検索データの読み込みに失敗しました。');
+async function fetchSearchData(): Promise<SearchResult[]> {
+  const res = await fetch("/api/search");
+  if (!res.ok) {
+    throw new Error(`検索データの取得に失敗しました (${res.status})`);
   }
+  return res.json() as Promise<SearchResult[]>;
 }
 
-/**
- * 検索用の記事データを取得（Lesson→Quest→Articleの構造をフラット化）
- */
-async function fetchArticlesForSearch(): Promise<SanityArticleForSearch[]> {
-  try {
-    const query = `*[_type == "lesson"] {
-      "lessonTitle": title,
-      "lessonSlug": slug.current,
-      "articles": quests[]->articles[]-> {
-        _id,
-        title,
-        slug,
-        excerpt,
-        "thumbnailUrl": coalesce(thumbnailUrl, thumbnail.asset->url),
-        tags,
-        isPremium,
-        videoDuration
-      }
-    }`;
-
-    const lessons = await client().fetch<
-      {
-        lessonTitle: string;
-        lessonSlug: string;
-        articles: SanityArticleForSearch[];
-      }[]
-    >(query);
-
-    // フラット化して親レッスン情報を付与
-    const allArticles: SanityArticleForSearch[] = [];
-    for (const lesson of lessons) {
-      if (lesson.articles) {
-        for (const article of lesson.articles) {
-          if (article) {
-            allArticles.push({
-              ...article,
-              lessonTitle: lesson.lessonTitle,
-              lessonSlug: lesson.lessonSlug,
-            });
-          }
-        }
-      }
-    }
-    return allArticles;
-  } catch (error) {
-    console.error('検索用記事データの取得に失敗:', error);
-    throw new Error('検索データの読み込みに失敗しました。');
-  }
-}
-
-/**
- * 検索用のガイドデータを取得
- */
-async function fetchGuidesForSearch(): Promise<SanityGuideForSearch[]> {
-  try {
-    const query = `*[_type == "guide"] | order(publishedAt desc) {
-      _id,
-      title,
-      "slug": slug.current,
-      description,
-      "thumbnailUrl": thumbnail.asset->url,
-      category,
-      tags,
-      publishedAt,
-      readingTime,
-      isPremium
-    }`;
-    return client().fetch(query);
-  } catch (error) {
-    console.error('検索用ガイドデータの取得に失敗:', error);
-    throw new Error('検索データの読み込みに失敗しました。');
-  }
-}
-
-// ============================================
-// 変換関数
-// ============================================
-
-function convertLessonToSearchResult(
-  lesson: SanityLessonForSearch & {
-    linkedRoadmaps?: { slug: string; title: string; shortTitle?: string }[];
-  }
-): LessonSearchResult {
-  return {
-    id: lesson._id,
-    type: "lesson",
-    title: lesson.title,
-    description: lesson.description || "",
-    slug: lesson.slug?.current || "",
-    thumbnail: lesson.thumbnailUrl,
-    category: lesson.categoryTitle,
-    tags: lesson.tags,
-    isPremium: lesson.isPremium,
-    lessonCount: lesson.articleCount,
-    linkedRoadmaps: lesson.linkedRoadmaps,
-  };
-}
-
-function convertArticleToSearchResult(
-  article: SanityArticleForSearch
-): ArticleSearchResult {
-  // videoDurationを分に変換
-  let readingTime: number | undefined;
-  if (article.videoDuration) {
-    if (typeof article.videoDuration === "number") {
-      readingTime = Math.ceil(article.videoDuration / 60);
-    } else if (typeof article.videoDuration === "string") {
-      // "MM:SS" or "HH:MM:SS" 形式をパース
-      const parts = article.videoDuration.split(":").map(Number);
-      if (parts.length === 2) {
-        readingTime = parts[0] + Math.ceil(parts[1] / 60);
-      } else if (parts.length === 3) {
-        readingTime = parts[0] * 60 + parts[1] + Math.ceil(parts[2] / 60);
-      }
-    }
-  }
-
-  return {
-    id: article._id,
-    type: "article",
-    title: article.title,
-    description: article.excerpt || "",
-    slug: article.slug?.current || "",
-    thumbnail: article.thumbnailUrl,
-    tags: article.tags,
-    isPremium: article.isPremium,
-    parentLessonTitle: article.lessonTitle,
-    parentLessonSlug: article.lessonSlug,
-    readingTime,
-  };
-}
-
-function convertGuideToSearchResult(
-  guide: SanityGuideForSearch
-): GuideSearchResult {
-  return {
-    id: guide._id,
-    type: "guide",
-    title: guide.title,
-    description: guide.description || "",
-    slug: guide.slug || "",
-    thumbnail: guide.thumbnailUrl,
-    category: guide.category,
-    tags: guide.tags,
-    publishedAt: guide.publishedAt,
-    readingTime: guide.readingTime,
-    isPremium: guide.isPremium ?? false,
-  };
-}
-
-// ============================================
-// 統合検索データ取得
-// ============================================
-
-async function fetchAllSearchData(): Promise<SearchResult[]> {
-  try {
-    const [lessons, articles, guides] = await Promise.all([
-      fetchLessonsForSearch(),
-      fetchArticlesForSearch(),
-      fetchGuidesForSearch(),
-    ]);
-
-    const results: SearchResult[] = [
-      ...lessons.map(convertLessonToSearchResult),
-      ...articles.map(convertArticleToSearchResult),
-      ...guides.map(convertGuideToSearchResult),
-    ];
-
-    return results;
-  } catch (error) {
-    console.error('統合検索データの取得に失敗:', error);
-    throw new Error('検索データの読み込みに失敗しました。ページを更新してもう一度お試しください。');
-  }
-}
-
-// ============================================
-// 検索ロジック
-// ============================================
+// ============================================================
+// 検索ロジック（クライアント側でフィルタリング）
+// ============================================================
 
 function filterSearchResults(
   data: SearchResult[],
@@ -276,12 +33,10 @@ function filterSearchResults(
 ): SearchResult[] {
   let results = data;
 
-  // コンテンツタイプでフィルタ
   if (contentTypes.length > 0) {
     results = results.filter((item) => contentTypes.includes(item.type));
   }
 
-  // テキスト検索
   if (query.trim()) {
     const normalizedQuery = query.toLowerCase().trim();
     results = results.filter((item) => {
@@ -293,7 +48,6 @@ function filterSearchResults(
       ]
         .join(" ")
         .toLowerCase();
-
       return searchableText.includes(normalizedQuery);
     });
   }
@@ -301,9 +55,9 @@ function filterSearchResults(
   return results;
 }
 
-// ============================================
+// ============================================================
 // React Query Hook
-// ============================================
+// ============================================================
 
 /**
  * 検索データを取得するフック
@@ -311,7 +65,7 @@ function filterSearchResults(
 export function useSearchData(enabled = true) {
   return useQuery({
     queryKey: ["searchData"],
-    queryFn: fetchAllSearchData,
+    queryFn: fetchSearchData,
     enabled,
     staleTime: 5 * 60 * 1000, // 5分
     gcTime: 10 * 60 * 1000, // 10分
@@ -321,14 +75,16 @@ export function useSearchData(enabled = true) {
 
 /**
  * 検索を実行するフック
- * @param enabled false にするとSanityフェッチを完全にスキップ（AIモード時など）
+ * @param enabled false にすると fetch を完全にスキップ（AI モード時など）
  */
-export function useSearch(query: string, contentTypes: SearchContentType[], enabled = true) {
+export function useSearch(
+  query: string,
+  contentTypes: SearchContentType[],
+  enabled = true
+) {
   const { data: allData, isLoading, error } = useSearchData(enabled);
 
-  const results = allData
-    ? filterSearchResults(allData, query, contentTypes)
-    : [];
+  const results = allData ? filterSearchResults(allData, query, contentTypes) : [];
 
   return {
     results,
@@ -339,15 +95,29 @@ export function useSearch(query: string, contentTypes: SearchContentType[], enab
 }
 
 /**
- * 検索候補を取得する関数（オートコンプリート用）
+ * 検索候補を取得する関数（オートコンプリート用、キャッシュ済データから即時抽出）
  */
 export function searchFromCache(
-  data: SearchResult[],
+  data: SearchResult[] | undefined,
   query: string,
-  limit: number = 8
+  limit = 8
 ): SearchResult[] {
-  if (!query.trim()) return [];
-
-  const results = filterSearchResults(data, query, []);
-  return results.slice(0, limit);
+  if (!data || !query.trim()) return [];
+  const normalizedQuery = query.toLowerCase().trim();
+  return data
+    .filter((item) => {
+      const searchableText = [
+        item.title,
+        item.description,
+        item.category || "",
+        ...(item.tags || []),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return searchableText.includes(normalizedQuery);
+    })
+    .slice(0, limit);
 }
+
+// 後方互換 re-export
+export { CONTENT_TYPE_LABELS, CONTENT_TYPE_ICONS };

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,353 @@
+import { useQuery } from "@tanstack/react-query";
+import { client } from "@/lib/sanity";
+import {
+  SearchResult,
+  LessonSearchResult,
+  ArticleSearchResult,
+  GuideSearchResult,
+  SearchContentType,
+} from "@/types/search";
+
+// ============================================
+// Sanityデータ型
+// ============================================
+
+interface SanityLessonForSearch {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  description?: string;
+  thumbnailUrl?: string;
+  category?: string;
+  categoryTitle?: string;
+  tags?: string[];
+  isPremium?: boolean;
+  articleCount: number;
+}
+
+interface SanityArticleForSearch {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  excerpt?: string;
+  thumbnailUrl?: string;
+  tags?: string[];
+  isPremium?: boolean;
+  videoDuration?: string | number;
+  lessonTitle?: string;
+  lessonSlug?: string;
+}
+
+interface SanityGuideForSearch {
+  _id: string;
+  title: string;
+  slug: string; // クエリで slug.current に解決済み
+  description?: string;
+  thumbnailUrl?: string;
+  category?: string;
+  tags?: string[];
+  publishedAt?: string;
+  readingTime?: string;
+  isPremium?: boolean;
+}
+
+// ============================================
+// Sanityクエリ
+// ============================================
+
+/**
+ * 検索用のレッスンデータを取得
+ */
+async function fetchLessonsForSearch(): Promise<SanityLessonForSearch[]> {
+  try {
+    // Lessons.tsx と同じ解決順序で thumbnail URL を coalesce
+    // 1) iconImageUrl, 2) iconImage の asset URL, 3) thumbnailUrl, 4) thumbnail の asset URL
+    const query = `*[_type == "lesson"] | order(_createdAt desc) {
+      _id,
+      title,
+      slug,
+      description,
+      "thumbnailUrl": coalesce(
+        iconImageUrl,
+        iconImage.asset->url,
+        thumbnailUrl,
+        thumbnail.asset->url
+      ),
+      "categoryTitle": category->title,
+      tags,
+      isPremium,
+      "articleCount": count(quests[]->articles[]),
+      "linkedRoadmaps": *[_type == "roadmap" && references(^._id)] {
+        "slug": slug.current,
+        title,
+        shortTitle
+      }
+    }`;
+    return client().fetch(query);
+  } catch (error) {
+    console.error('検索用レッスンデータの取得に失敗:', error);
+    throw new Error('検索データの読み込みに失敗しました。');
+  }
+}
+
+/**
+ * 検索用の記事データを取得（Lesson→Quest→Articleの構造をフラット化）
+ */
+async function fetchArticlesForSearch(): Promise<SanityArticleForSearch[]> {
+  try {
+    const query = `*[_type == "lesson"] {
+      "lessonTitle": title,
+      "lessonSlug": slug.current,
+      "articles": quests[]->articles[]-> {
+        _id,
+        title,
+        slug,
+        excerpt,
+        "thumbnailUrl": coalesce(thumbnailUrl, thumbnail.asset->url),
+        tags,
+        isPremium,
+        videoDuration
+      }
+    }`;
+
+    const lessons = await client().fetch<
+      {
+        lessonTitle: string;
+        lessonSlug: string;
+        articles: SanityArticleForSearch[];
+      }[]
+    >(query);
+
+    // フラット化して親レッスン情報を付与
+    const allArticles: SanityArticleForSearch[] = [];
+    for (const lesson of lessons) {
+      if (lesson.articles) {
+        for (const article of lesson.articles) {
+          if (article) {
+            allArticles.push({
+              ...article,
+              lessonTitle: lesson.lessonTitle,
+              lessonSlug: lesson.lessonSlug,
+            });
+          }
+        }
+      }
+    }
+    return allArticles;
+  } catch (error) {
+    console.error('検索用記事データの取得に失敗:', error);
+    throw new Error('検索データの読み込みに失敗しました。');
+  }
+}
+
+/**
+ * 検索用のガイドデータを取得
+ */
+async function fetchGuidesForSearch(): Promise<SanityGuideForSearch[]> {
+  try {
+    const query = `*[_type == "guide"] | order(publishedAt desc) {
+      _id,
+      title,
+      "slug": slug.current,
+      description,
+      "thumbnailUrl": thumbnail.asset->url,
+      category,
+      tags,
+      publishedAt,
+      readingTime,
+      isPremium
+    }`;
+    return client().fetch(query);
+  } catch (error) {
+    console.error('検索用ガイドデータの取得に失敗:', error);
+    throw new Error('検索データの読み込みに失敗しました。');
+  }
+}
+
+// ============================================
+// 変換関数
+// ============================================
+
+function convertLessonToSearchResult(
+  lesson: SanityLessonForSearch & {
+    linkedRoadmaps?: { slug: string; title: string; shortTitle?: string }[];
+  }
+): LessonSearchResult {
+  return {
+    id: lesson._id,
+    type: "lesson",
+    title: lesson.title,
+    description: lesson.description || "",
+    slug: lesson.slug?.current || "",
+    thumbnail: lesson.thumbnailUrl,
+    category: lesson.categoryTitle,
+    tags: lesson.tags,
+    isPremium: lesson.isPremium,
+    lessonCount: lesson.articleCount,
+    linkedRoadmaps: lesson.linkedRoadmaps,
+  };
+}
+
+function convertArticleToSearchResult(
+  article: SanityArticleForSearch
+): ArticleSearchResult {
+  // videoDurationを分に変換
+  let readingTime: number | undefined;
+  if (article.videoDuration) {
+    if (typeof article.videoDuration === "number") {
+      readingTime = Math.ceil(article.videoDuration / 60);
+    } else if (typeof article.videoDuration === "string") {
+      // "MM:SS" or "HH:MM:SS" 形式をパース
+      const parts = article.videoDuration.split(":").map(Number);
+      if (parts.length === 2) {
+        readingTime = parts[0] + Math.ceil(parts[1] / 60);
+      } else if (parts.length === 3) {
+        readingTime = parts[0] * 60 + parts[1] + Math.ceil(parts[2] / 60);
+      }
+    }
+  }
+
+  return {
+    id: article._id,
+    type: "article",
+    title: article.title,
+    description: article.excerpt || "",
+    slug: article.slug?.current || "",
+    thumbnail: article.thumbnailUrl,
+    tags: article.tags,
+    isPremium: article.isPremium,
+    parentLessonTitle: article.lessonTitle,
+    parentLessonSlug: article.lessonSlug,
+    readingTime,
+  };
+}
+
+function convertGuideToSearchResult(
+  guide: SanityGuideForSearch
+): GuideSearchResult {
+  return {
+    id: guide._id,
+    type: "guide",
+    title: guide.title,
+    description: guide.description || "",
+    slug: guide.slug || "",
+    thumbnail: guide.thumbnailUrl,
+    category: guide.category,
+    tags: guide.tags,
+    publishedAt: guide.publishedAt,
+    readingTime: guide.readingTime,
+    isPremium: guide.isPremium ?? false,
+  };
+}
+
+// ============================================
+// 統合検索データ取得
+// ============================================
+
+async function fetchAllSearchData(): Promise<SearchResult[]> {
+  try {
+    const [lessons, articles, guides] = await Promise.all([
+      fetchLessonsForSearch(),
+      fetchArticlesForSearch(),
+      fetchGuidesForSearch(),
+    ]);
+
+    const results: SearchResult[] = [
+      ...lessons.map(convertLessonToSearchResult),
+      ...articles.map(convertArticleToSearchResult),
+      ...guides.map(convertGuideToSearchResult),
+    ];
+
+    return results;
+  } catch (error) {
+    console.error('統合検索データの取得に失敗:', error);
+    throw new Error('検索データの読み込みに失敗しました。ページを更新してもう一度お試しください。');
+  }
+}
+
+// ============================================
+// 検索ロジック
+// ============================================
+
+function filterSearchResults(
+  data: SearchResult[],
+  query: string,
+  contentTypes: SearchContentType[]
+): SearchResult[] {
+  let results = data;
+
+  // コンテンツタイプでフィルタ
+  if (contentTypes.length > 0) {
+    results = results.filter((item) => contentTypes.includes(item.type));
+  }
+
+  // テキスト検索
+  if (query.trim()) {
+    const normalizedQuery = query.toLowerCase().trim();
+    results = results.filter((item) => {
+      const searchableText = [
+        item.title,
+        item.description,
+        item.category || "",
+        ...(item.tags || []),
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return searchableText.includes(normalizedQuery);
+    });
+  }
+
+  return results;
+}
+
+// ============================================
+// React Query Hook
+// ============================================
+
+/**
+ * 検索データを取得するフック
+ */
+export function useSearchData(enabled = true) {
+  return useQuery({
+    queryKey: ["searchData"],
+    queryFn: fetchAllSearchData,
+    enabled,
+    staleTime: 5 * 60 * 1000, // 5分
+    gcTime: 10 * 60 * 1000, // 10分
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
+ * 検索を実行するフック
+ * @param enabled false にするとSanityフェッチを完全にスキップ（AIモード時など）
+ */
+export function useSearch(query: string, contentTypes: SearchContentType[], enabled = true) {
+  const { data: allData, isLoading, error } = useSearchData(enabled);
+
+  const results = allData
+    ? filterSearchResults(allData, query, contentTypes)
+    : [];
+
+  return {
+    results,
+    isLoading,
+    error,
+    totalCount: results.length,
+  };
+}
+
+/**
+ * 検索候補を取得する関数（オートコンプリート用）
+ */
+export function searchFromCache(
+  data: SearchResult[],
+  query: string,
+  limit: number = 8
+): SearchResult[] {
+  if (!query.trim()) return [];
+
+  const results = filterSearchResults(data, query, []);
+  return results.slice(0, limit);
+}

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -26,6 +26,36 @@ async function fetchSearchData(): Promise<SearchResult[]> {
 // 検索ロジック（クライアント側でフィルタリング）
 // ============================================================
 
+/**
+ * クエリのマッチ判定
+ * - 英数字のみのクエリ: 単語境界 (\b) で大文字小文字無視マッチ
+ *   → 「AI」が「Daily」の "ai" に誤ヒットしないようにする
+ * - それ以外（日本語など）: 通常の lowercase 部分一致
+ *   → 「情」で「情報設計」がヒットする挙動を維持
+ */
+function matchesQuery(haystack: string, needle: string): boolean {
+  const trimmed = needle.trim();
+  if (!trimmed) return true;
+
+  const isAsciiOnly = /^[\x20-\x7E]+$/.test(trimmed);
+  if (isAsciiOnly) {
+    const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`\\b${escaped}\\b`, "i");
+    return regex.test(haystack);
+  }
+
+  return haystack.toLowerCase().includes(trimmed.toLowerCase());
+}
+
+function buildSearchableText(item: SearchResult): string {
+  return [
+    item.title,
+    item.description,
+    item.category || "",
+    ...(item.tags || []),
+  ].join(" ");
+}
+
 function filterSearchResults(
   data: SearchResult[],
   query: string,
@@ -38,18 +68,9 @@ function filterSearchResults(
   }
 
   if (query.trim()) {
-    const normalizedQuery = query.toLowerCase().trim();
-    results = results.filter((item) => {
-      const searchableText = [
-        item.title,
-        item.description,
-        item.category || "",
-        ...(item.tags || []),
-      ]
-        .join(" ")
-        .toLowerCase();
-      return searchableText.includes(normalizedQuery);
-    });
+    results = results.filter((item) =>
+      matchesQuery(buildSearchableText(item), query)
+    );
   }
 
   return results;
@@ -103,19 +124,8 @@ export function searchFromCache(
   limit = 8
 ): SearchResult[] {
   if (!data || !query.trim()) return [];
-  const normalizedQuery = query.toLowerCase().trim();
   return data
-    .filter((item) => {
-      const searchableText = [
-        item.title,
-        item.description,
-        item.category || "",
-        ...(item.tags || []),
-      ]
-        .join(" ")
-        .toLowerCase();
-      return searchableText.includes(normalizedQuery);
-    })
+    .filter((item) => matchesQuery(buildSearchableText(item), query))
     .slice(0, limit);
 }
 

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -1,0 +1,154 @@
+/**
+ * BONO 診断ユーティリティ
+ * コンソールで問題の原因を素早く特定するためのチェック関数
+ *
+ * ブラウザコンソールから手動実行:
+ *   window.__bonoDiag?.()
+ */
+
+const LOG_PREFIX = '[BONO Diag]';
+
+function log(label: string, status: 'ok' | 'warn' | 'error', message: string, detail?: unknown) {
+  const icon = status === 'ok' ? '✅' : status === 'warn' ? '⚠️' : '❌';
+  const style = status === 'ok' ? 'color: green' : status === 'warn' ? 'color: orange' : 'color: red; font-weight: bold';
+  console.log(`%c${LOG_PREFIX} ${icon} [${label}] ${message}`, style);
+  if (detail) console.log(`   └─`, detail);
+}
+
+// ============================================
+// 環境変数チェック
+// ============================================
+function checkEnvVars() {
+  console.groupCollapsed(`${LOG_PREFIX} 環境変数チェック`);
+
+  const vars = [
+    { key: 'NEXT_PUBLIC_SANITY_PROJECT_ID', val: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID },
+    { key: 'NEXT_PUBLIC_SANITY_DATASET',    val: process.env.NEXT_PUBLIC_SANITY_DATASET },
+    { key: 'NEXT_PUBLIC_SANITY_API_VERSION',val: process.env.NEXT_PUBLIC_SANITY_API_VERSION },
+  ];
+
+  let allOk = true;
+  for (const { key, val } of vars) {
+    if (val) {
+      log(key, 'ok', val);
+    } else {
+      log(key, 'error', '未設定 — Vercel の Environment Variables を確認してください');
+      allOk = false;
+    }
+  }
+
+  if (allOk) log('ENV', 'ok', '全環境変数 OK');
+  console.groupEnd();
+}
+
+// ============================================
+// Sanity 接続チェック
+// ============================================
+async function checkSanityConnection() {
+  console.groupCollapsed(`${LOG_PREFIX} Sanity 接続チェック`);
+
+  const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+  const dataset   = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production';
+
+  if (!projectId) {
+    log('Sanity', 'error', 'VITE_SANITY_PROJECT_ID が未設定のためスキップ');
+    console.groupEnd();
+    return;
+  }
+
+  const url = `https://${projectId}.apicdn.sanity.io/v2024-01-01/data/query/${dataset}?query=*[_type%3D%3D"lesson"][0...1]{_id}`;
+
+  try {
+    const res = await fetch(url);
+
+    if (res.ok) {
+      const data = await res.json();
+      log('Sanity CDN', 'ok', `接続成功 (${data.result?.length ?? 0}件取得)`);
+    } else if (res.status === 403) {
+      log('Sanity CDN', 'error',
+        `403 Forbidden — このドメインが Sanity の CORS 許可リストにありません`,
+        {
+          現在のドメイン: window.location.origin,
+          修正方法: 'manage.sanity.io → API → CORS Origins → Add → ' + window.location.origin,
+        }
+      );
+    } else {
+      log('Sanity CDN', 'warn', `予期しないステータス: ${res.status}`, await res.text());
+    }
+  } catch (err: any) {
+    if (err?.message?.includes('Failed to fetch') || err?.message?.includes('NetworkError')) {
+      log('Sanity CDN', 'error',
+        'ネットワークエラー（CORS ブロックの可能性大）',
+        {
+          現在のドメイン: window.location.origin,
+          修正方法: 'manage.sanity.io → API → CORS Origins に追加してください',
+          エラー詳細: err.message,
+        }
+      );
+    } else {
+      log('Sanity CDN', 'error', `不明なエラー: ${err?.message}`, err);
+    }
+  }
+
+  console.groupEnd();
+}
+
+// ============================================
+// AI (api/ai-chat) 接続チェック
+// ============================================
+async function checkAIEndpoint() {
+  console.groupCollapsed(`${LOG_PREFIX} AI エンドポイント チェック`);
+
+  try {
+    const res = await fetch('/api/ai-chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'テスト' }] }),
+    });
+
+    if (res.ok || res.headers.get('content-type')?.includes('text/event-stream')) {
+      log('AI endpoint', 'ok', '/api/ai-chat は応答しています');
+      res.body?.cancel(); // ストリームを閉じる
+    } else if (res.status === 500) {
+      const body = await res.text();
+      log('AI endpoint', 'error',
+        `500 Internal Server Error — サーバー側のエラー（GROQ_API_KEY が Vercel に設定されているか確認）`,
+        { レスポンス: body }
+      );
+    } else if (res.status === 405) {
+      log('AI endpoint', 'warn', `405 — GET リクエストは不可（正常: POST のみ受け付ける）`);
+    } else {
+      log('AI endpoint', 'warn', `ステータス: ${res.status}`, await res.text());
+    }
+  } catch (err: any) {
+    log('AI endpoint', 'error',
+      '/api/ai-chat に到達できません。Vercel にデプロイされていない可能性があります',
+      err?.message
+    );
+  }
+
+  console.groupEnd();
+}
+
+// ============================================
+// 全診断を実行
+// ============================================
+export async function runDiagnostics() {
+  console.group(`${LOG_PREFIX} ===== BONO 診断開始 =====`);
+  console.log(`ページ: ${window.location.href}`);
+  console.log(`時刻: ${new Date().toLocaleString('ja-JP')}`);
+  console.groupEnd();
+
+  checkEnvVars();
+  await checkSanityConnection();
+  await checkAIEndpoint();
+
+  console.log(`${LOG_PREFIX} ===== 診断完了 =====`);
+  console.log(`${LOG_PREFIX} 問題が見つかった場合は上記の「修正方法」を参照してください`);
+}
+
+// ブラウザコンソールから window.__bonoDiag() で手動実行できるようにする
+if (typeof window !== 'undefined') {
+  (window as any).__bonoDiag = runDiagnostics;
+  console.log(`${LOG_PREFIX} 💡 コンソールで window.__bonoDiag() を実行すると詳細診断ができます`);
+}

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -1,0 +1,8 @@
+/**
+ * 外部サービス / 外部 URL の定数
+ * 1 箇所に集約することで URL 変更時の修正範囲を最小化
+ */
+
+/** カイクンへの質問用 Slack チャンネル */
+export const SLACK_QUESTIONS_URL =
+  "https://bonoco.slack.com/archives/C04JJHFDGTT";

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,229 @@
+/**
+ * 検索機能の型定義
+ *
+ * 4つのコンテンツタイプを統一的に扱う：
+ * - lesson: レッスンコース
+ * - article: レッスンコース内の記事
+ * - guide: ガイドコンテンツ
+ * - roadmap: ロードマップ
+ */
+
+// ============================================
+// コンテンツタイプ
+// ============================================
+
+/** 検索対象のコンテンツタイプ */
+export type SearchContentType = "lesson" | "article" | "guide" | "roadmap";
+
+/** コンテンツタイプのラベル */
+export const CONTENT_TYPE_LABELS: Record<SearchContentType, string> = {
+  lesson: "レッスン",
+  article: "記事",
+  guide: "ガイド",
+  roadmap: "ロードマップ",
+};
+
+/** コンテンツタイプのアイコン（絵文字） */
+export const CONTENT_TYPE_ICONS: Record<SearchContentType, string> = {
+  lesson: "📚",
+  article: "📝",
+  guide: "💡",
+  roadmap: "🗺️",
+};
+
+/** コンテンツタイプのカラー設定 */
+export const CONTENT_TYPE_COLORS: Record<
+  SearchContentType,
+  {
+    bg: string;
+    text: string;
+    border: string;
+    accent: string;
+  }
+> = {
+  lesson: {
+    bg: "bg-amber-50",
+    text: "text-amber-800",
+    border: "border-amber-200",
+    accent: "bg-amber-500",
+  },
+  article: {
+    bg: "bg-emerald-50",
+    text: "text-emerald-800",
+    border: "border-emerald-200",
+    accent: "bg-emerald-500",
+  },
+  guide: {
+    bg: "bg-blue-50",
+    text: "text-blue-800",
+    border: "border-blue-200",
+    accent: "bg-blue-500",
+  },
+  roadmap: {
+    bg: "bg-purple-50",
+    text: "text-purple-800",
+    border: "border-purple-200",
+    accent: "bg-purple-500",
+  },
+};
+
+// ============================================
+// 検索結果の型
+// ============================================
+
+/** 検索結果の基本インターフェース */
+export interface SearchResultBase {
+  /** 一意のID */
+  id: string;
+  /** コンテンツタイプ */
+  type: SearchContentType;
+  /** タイトル */
+  title: string;
+  /** 説明文 */
+  description: string;
+  /** URL用スラッグまたはパス */
+  slug: string;
+  /** サムネイル画像URL（任意） */
+  thumbnail?: string;
+  /** カテゴリ（任意） */
+  category?: string;
+  /** タグ（任意） */
+  tags?: string[];
+  /** プレミアムコンテンツか */
+  isPremium?: boolean;
+}
+
+/** レッスンコースの検索結果 */
+export interface LessonSearchResult extends SearchResultBase {
+  type: "lesson";
+  /** レッスン数 */
+  lessonCount?: number;
+  /** 紐づくロードマップ（LessonCard と同じ構造） */
+  linkedRoadmaps?: {
+    slug: string;
+    title: string;
+    shortTitle?: string;
+  }[];
+}
+
+/** 記事の検索結果（レッスンコース内） */
+export interface ArticleSearchResult extends SearchResultBase {
+  type: "article";
+  /** 親レッスンコースのタイトル */
+  parentLessonTitle?: string;
+  /** 親レッスンコースのスラッグ */
+  parentLessonSlug?: string;
+  /** 読了時間（分） */
+  readingTime?: number;
+}
+
+/** ガイドの検索結果 */
+export interface GuideSearchResult extends SearchResultBase {
+  type: "guide";
+  /** 読了時間（例: "10分"） */
+  readingTime?: string;
+  /** 公開日 */
+  publishedAt?: string;
+  /** 著者 */
+  author?: string;
+}
+
+/** ロードマップの検索結果 */
+export interface RoadmapSearchResult extends SearchResultBase {
+  type: "roadmap";
+  /** 期間（例: "6ヶ月"） */
+  duration?: string;
+  /** ステップ数 */
+  stepsCount?: number;
+  /** レッスン数 */
+  lessonsCount?: number;
+  /** グラデーション色（例: "from-blue-500 to-purple-600"） */
+  gradientColors?: string;
+}
+
+/** 検索結果の統一型 */
+export type SearchResult =
+  | LessonSearchResult
+  | ArticleSearchResult
+  | GuideSearchResult
+  | RoadmapSearchResult;
+
+// ============================================
+// 検索フィルター
+// ============================================
+
+/** 検索フィルター */
+export interface SearchFilters {
+  /** 検索クエリ */
+  query: string;
+  /** フィルタするコンテンツタイプ（空の場合は全て） */
+  contentTypes: SearchContentType[];
+  /** フィルタするカテゴリ（空の場合は全て） */
+  categories: string[];
+  /** プレミアムコンテンツのみ */
+  premiumOnly?: boolean;
+}
+
+/** デフォルトのフィルター */
+export const DEFAULT_SEARCH_FILTERS: SearchFilters = {
+  query: "",
+  contentTypes: [],
+  categories: [],
+  premiumOnly: false,
+};
+
+// ============================================
+// 検索結果のグループ化
+// ============================================
+
+/** コンテンツタイプ別にグループ化された検索結果 */
+export interface GroupedSearchResults {
+  lesson: LessonSearchResult[];
+  article: ArticleSearchResult[];
+  guide: GuideSearchResult[];
+  roadmap: RoadmapSearchResult[];
+}
+
+/** 検索結果をタイプ別にグループ化 */
+export function groupSearchResults(
+  results: SearchResult[]
+): GroupedSearchResults {
+  return {
+    lesson: results.filter((r): r is LessonSearchResult => r.type === "lesson"),
+    article: results.filter(
+      (r): r is ArticleSearchResult => r.type === "article"
+    ),
+    guide: results.filter((r): r is GuideSearchResult => r.type === "guide"),
+    roadmap: results.filter(
+      (r): r is RoadmapSearchResult => r.type === "roadmap"
+    ),
+  };
+}
+
+// ============================================
+// 型ガード
+// ============================================
+
+export function isLessonResult(
+  result: SearchResult
+): result is LessonSearchResult {
+  return result.type === "lesson";
+}
+
+export function isArticleResult(
+  result: SearchResult
+): result is ArticleSearchResult {
+  return result.type === "article";
+}
+
+export function isGuideResult(
+  result: SearchResult
+): result is GuideSearchResult {
+  return result.type === "guide";
+}
+
+export function isRoadmapResult(
+  result: SearchResult
+): result is RoadmapSearchResult {
+  return result.type === "roadmap";
+}


### PR DESCRIPTION
## Summary

Vite版 `feature/search` (PR #109) で実装した検索体験を、現 `origin/main` の **Next.js 16 App Router** に完全移植。CLAUDE.md の移植ルール（コピー＋最小限の Next.js 適応、独自書き直し禁止）に準拠。

PR #109 はベースが古い Vite ブランチで現 main にマージ不可だったため、新 PR を発行。

## 主要追加機能

| 機能 | パス |
|---|---|
| 検索ページ（タブ統合 UI） | `/search` |
| AI 学習アシスタント | `/search?tab=ai`（Groq llama-3.3-70b、SSE ストリーミング） |
| サイドバー検索ボックス | 全ページ |
| 結果カード共通化 | `HorizontalContentCard`（lesson / article / guide variant） |
| dev ショーケース | `/dev/search-card` |

## Next.js 適応の主な置換

- \`react-router-dom\` → \`next/navigation\`（useRouter / useSearchParams / usePathname）
- \`<Link to>\` → \`<Link href>\`
- \`api/ai-chat.ts\`（Vercel Function）→ \`src/app/api/ai-chat/route.ts\`（Route Handler）
- \`import.meta.env.VITE_*\` → \`process.env.NEXT_PUBLIC_*\`
- \`client.fetch\` → \`client().fetch\`（Next.js 版 \`lib/sanity.ts\` は関数 export）
- \`<Layout>\` ラッパー削除（root layout で組込済）
- \`useSubscriptionContext\` → 一律 false（別イシューで対応）

## 必要な環境変数（Vercel）

- \`NEXT_PUBLIC_SANITY_PROJECT_ID\` / \`DATASET\` / \`API_VERSION\` ✅
- \`GROQ_API_KEY\` ✅（AI 機能で必須）

## 検証

- [x] \`npx tsc --noEmit\` 通過
- [x] dev サーバー全エンドポイント 200
- [ ] Vercel preview deploy で AI 応答動作確認
- [ ] \`npm run build\`：Sanity API 一時タイムアウトで失敗中（Vercel 上では通る想定）

## レビュー観点

詳細チェックリストは Linear 連携 doc \`検索：結果オブジェクトの整理が.md\` を参照。

## Related

- Supersedes: #109 (Vite 版、本 PR マージ後にクローズ予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)