### PR TITLE
fix: タスク詳細のMarkdownフォールバックをセクション分割描画に移植

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.7.1",
         "recharts": "^3.8.0",
+        "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "resend": "^6.9.4",
         "server-only": "^0.0.1",
@@ -9949,6 +9950,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -9970,6 +9984,22 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10011,6 +10041,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hono": {
@@ -11551,6 +11590,21 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -14117,6 +14171,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -16003,6 +16074,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.7.1",
     "recharts": "^3.8.0",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "resend": "^6.9.4",
     "server-only": "^0.0.1",

--- a/scripts/fix-book-lending-contamination.ts
+++ b/scripts/fix-book-lending-contamination.ts
@@ -1,0 +1,229 @@
+/**
+ * 本貸出（book-lending-system）コンテンツ汚染の修正スクリプト
+ *
+ * 背景:
+ *   training タスクの import 時に、book-lending-system の sections（お題説明）が
+ *   他トレーニングの content.md frontmatter `sections:` に丸ごとコピペされ、
+ *   それが Sanity の trainingTask.sections[] にも取り込まれてしまった。
+ *   各お題の「正しい本文」は body markdown（= Sanity の "本文" セクション）に存在する。
+ *
+ * このスクリプトが直すもの:
+ *   (A) Sanity: 汚染された trainingTask ドキュメントの sections[] を、
+ *       既存の "本文" セクション1つ（正しい body の Portable Text）に置き換える。
+ *       → markdown→PT 変換は行わず、既に正しい PT を再利用するので安全。
+ *   (B) Storage: kintai-kyuka-shinsei の content.md frontmatter `title:` が
+ *       本貸出のままなので、正しいお題タイトルに修正する。
+ *
+ * このスクリプトが触らないもの:
+ *   - Storage frontmatter の `sections:` 汚染（現状コードでは描画に未使用＝潜在的）。
+ *     hygiene 目的の別フェーズとして扱う。
+ *   - book-lending-system 自身（正規データ）。
+ *
+ * 実行:
+ *   npx tsx scripts/fix-book-lending-contamination.ts            # dry-run（既定・変更なし）
+ *   npx tsx scripts/fix-book-lending-contamination.ts --apply    # 実適用
+ *
+ * 適用前に各 Sanity ドキュメントの現 sections を scripts/.backups/ に保存する。
+ */
+
+import { createClient } from "@sanity/client";
+import { config } from "dotenv";
+import { resolve } from "path";
+import { mkdirSync, writeFileSync } from "fs";
+
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+const APPLY = process.argv.includes("--apply");
+const MODE = APPLY ? "APPLY" : "DRY-RUN";
+
+// 本貸出セクションの識別文字列（汚染の指紋）
+const BOOK_MARKER = "社内で必要な本を、確実に借りて返せるようにしたい";
+// 汚染の出どころ（これは正規データなので除外）
+const SOURCE_SLUG = "book-lending-system";
+
+// (B) kintai title 修正
+const KINTAI_PATH = "kintai-kyuka-shinsei/tasks/explain/content.md";
+const KINTAI_WRONG_TITLE = "お題について：社内本貸し出しシステム";
+const KINTAI_CORRECT_TITLE = "お題について：休暇申請システム";
+
+const SANITY_PROJECT_ID =
+  process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.SANITY_PROJECT_ID;
+const SANITY_DATASET =
+  process.env.NEXT_PUBLIC_SANITY_DATASET || process.env.SANITY_DATASET || "production";
+const SANITY_API_VERSION =
+  process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2024-01-01";
+const SANITY_WRITE_TOKEN = process.env.SANITY_WRITE_TOKEN;
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const BUCKET = "training-content";
+
+if (APPLY && !SANITY_WRITE_TOKEN) {
+  console.error("⚠️  --apply には SANITY_WRITE_TOKEN が必要です");
+  process.exit(1);
+}
+if (APPLY && (!SUPABASE_URL || !SERVICE_ROLE)) {
+  console.error("⚠️  --apply には SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が必要です");
+  process.exit(1);
+}
+
+const sanity = createClient({
+  projectId: SANITY_PROJECT_ID,
+  dataset: SANITY_DATASET,
+  apiVersion: SANITY_API_VERSION,
+  token: SANITY_WRITE_TOKEN,
+  useCdn: false,
+});
+
+interface Section {
+  _key: string;
+  sectionTitle?: string;
+  sectionType?: string;
+  content?: unknown[];
+}
+interface TaskDoc {
+  _id: string;
+  title?: string;
+  tslug?: string;
+  sections?: Section[];
+}
+
+const firstHeading = (content: unknown[] | undefined): string => {
+  for (const b of content || []) {
+    const blk = b as { _type?: string; style?: string; children?: { text?: string }[] };
+    if (blk._type === "block" && /^h[1-3]$/.test(blk.style || "")) {
+      return (blk.children || []).map((c) => c.text || "").join("").trim();
+    }
+  }
+  // 見出しが無ければ最初の非空テキスト
+  for (const b of content || []) {
+    const blk = b as { _type?: string; children?: { text?: string }[] };
+    const t = (blk.children || []).map((c) => c.text || "").join("").trim();
+    if (t) return t;
+  }
+  return "(本文に見出しなし)";
+};
+
+async function fixSanity() {
+  console.log("\n========== (A) Sanity sections 汚染修正 ==========");
+
+  // 汚染ドキュメントを自動検出: 先頭セクションが本貸出 marker かつ出どころ以外
+  const docs: TaskDoc[] = await sanity.fetch(
+    `*[_type=="trainingTask"
+        && training->slug.current != $src
+        && sections[0].sectionTitle match $marker
+      ]{ _id, title, "tslug": training->slug.current, sections }`,
+    { src: SOURCE_SLUG, marker: BOOK_MARKER + "*" }
+  );
+
+  if (!docs.length) {
+    console.log("汚染ドキュメントは検出されませんでした（既に修正済みの可能性）。");
+    return;
+  }
+
+  console.log(`検出: ${docs.length} 件\n`);
+  const backupDir = resolve(__dirname, ".backups");
+  if (APPLY) mkdirSync(backupDir, { recursive: true });
+
+  for (const doc of docs) {
+    const secs = doc.sections || [];
+    const hon = secs.find((s) => s.sectionTitle === "本文");
+
+    console.log(`■ ${doc._id}`);
+    console.log(`   training : ${doc.tslug}`);
+    console.log(`   title    : ${doc.title}`);
+    console.log(`   現 sections: ${secs.length} 個（先頭 = "${secs[0]?.sectionTitle?.slice(0, 30)}…" ← 本貸出）`);
+
+    if (!hon) {
+      console.log(`   ⚠️  "本文" セクションが見つからないためスキップ（要手動確認）\n`);
+      continue;
+    }
+    const honHeading = firstHeading(hon.content);
+    console.log(`   "本文" 先頭見出し: 「${honHeading}」 ← この内容で1セクションに置き換え`);
+    console.log(`   → 新 sections: 1 個（sectionTitle="" / content=本文の ${hon.content?.length ?? 0} ブロック）`);
+
+    // 安全弁: 本文がまだ本貸出のままなら触らない
+    if (honHeading.includes("社内で必要な本") && doc.tslug !== SOURCE_SLUG) {
+      console.log(`   ⚠️  "本文" も本貸出に見えるためスキップ（要手動確認）\n`);
+      continue;
+    }
+
+    const newSection: Section = {
+      ...hon,
+      sectionTitle: "", // 余計な見出しを出さない（本文内部の h2 が先頭になる）
+    };
+
+    if (APPLY) {
+      writeFileSync(
+        resolve(backupDir, `${doc._id}.sections.json`),
+        JSON.stringify(secs, null, 2)
+      );
+      await sanity.patch(doc._id).set({ sections: [newSection] }).commit();
+      console.log(`   ✅ 適用済み（バックアップ: scripts/.backups/${doc._id}.sections.json）\n`);
+    } else {
+      console.log(`   (dry-run: 変更なし)\n`);
+    }
+  }
+}
+
+async function fixKintaiTitle() {
+  console.log("\n========== (B) kintai Storage title 修正 ==========");
+  const headers = {
+    Authorization: `Bearer ${SERVICE_ROLE}`,
+    apikey: SERVICE_ROLE as string,
+  };
+  const getUrl = `${SUPABASE_URL}/storage/v1/object/${BUCKET}/${KINTAI_PATH}`;
+  const res = await fetch(getUrl, { headers });
+  if (!res.ok) {
+    console.log(`   ⚠️  取得失敗 (${res.status})。スキップ。`);
+    return;
+  }
+  const md = await res.text();
+
+  const hasWrong = md.includes(`title: "${KINTAI_WRONG_TITLE}"`);
+  console.log(`   path        : ${KINTAI_PATH}`);
+  console.log(`   現 title    : ${hasWrong ? KINTAI_WRONG_TITLE + " ← 誤り" : "(誤りタイトル未検出)"}`);
+  console.log(`   修正後 title: ${KINTAI_CORRECT_TITLE}`);
+
+  if (!hasWrong) {
+    console.log(`   (既に修正済み or タイトル形が想定外。スキップ)\n`);
+    return;
+  }
+
+  const fixed = md.replace(
+    `title: "${KINTAI_WRONG_TITLE}"`,
+    `title: "${KINTAI_CORRECT_TITLE}"`
+  );
+
+  if (APPLY) {
+    const putRes = await fetch(getUrl, {
+      method: "PUT",
+      headers: { ...headers, "x-upsert": "true", "Content-Type": "text/markdown" },
+      body: fixed,
+    });
+    if (!putRes.ok) {
+      console.log(`   ⚠️  アップロード失敗 (${putRes.status}: ${await putRes.text()})\n`);
+      return;
+    }
+    console.log(`   ✅ 適用済み\n`);
+  } else {
+    console.log(`   (dry-run: 変更なし)\n`);
+  }
+}
+
+async function main() {
+  console.log(`\n##### 本貸出汚染 修正スクリプト [${MODE}] #####`);
+  console.log(`Sanity: ${SANITY_PROJECT_ID}/${SANITY_DATASET}`);
+  await fixSanity();
+  await fixKintaiTitle();
+  console.log("##### 完了 #####");
+  if (!APPLY) {
+    console.log("\n→ 内容を確認後、適用するには: npx tsx scripts/fix-book-lending-contamination.ts --apply");
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/training/[trainingSlug]/[taskSlug]/page.tsx
+++ b/src/app/training/[trainingSlug]/[taskSlug]/page.tsx
@@ -7,6 +7,9 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { BackButton } from "@/components/common/BackButton";
 import NavigationHeader from "@/components/training/NavigationHeader";
 import PortableTextRenderer from "@/components/common/PortableTextRenderer";
+import ContentSection from "@/components/training/ContentSection";
+import DesignSolutionSection from "@/components/training/DesignSolutionSection";
+import { parseContentSections } from "@/utils/parseContentSections";
 import type { SanitySection } from "@/types/training";
 
 interface PageProps {
@@ -127,10 +130,36 @@ export default async function TaskDetailPage({ params }: PageProps) {
                     </div>
                   ))
                 ) : task.content ? (
-                  /* Markdownフォールバック */
-                  <div className="prose prose-gray max-w-none">
-                    {task.content}
-                  </div>
+                  /* Markdownフォールバック（Sanity sections未移行のタスク向け）— mainのTaskDetailPage:377-407 と同じ構成 */
+                  parseContentSections(task.content).map((section, index) => (
+                    <div key={index} className="mb-6">
+                      {section.type === "design-solution" ? (
+                        <DesignSolutionSection content={section.content} />
+                      ) : section.type === "premium-only" ? (
+                        task.hasAccess ? (
+                          <ContentSection title={section.title} content={section.content} />
+                        ) : (
+                          <div className="border-2 border-orange-200 rounded-lg p-6 bg-orange-50">
+                            <div className="flex items-center gap-3 mb-3">
+                              <span className="text-2xl">🔒</span>
+                              <h3 className="text-lg font-bold text-orange-800">{section.title}</h3>
+                            </div>
+                            <div className="text-orange-600 text-sm mb-4">
+                              このセクションはメンバー限定コンテンツです。
+                            </div>
+                            <Link
+                              href="/subscription"
+                              className="inline-block bg-orange-600 hover:bg-orange-700 text-white px-4 py-2 rounded-lg text-sm transition-colors"
+                            >
+                              プランを確認
+                            </Link>
+                          </div>
+                        )
+                      ) : (
+                        <ContentSection title={section.title} content={section.content} />
+                      )}
+                    </div>
+                  ))
                 ) : !task.description ? (
                   <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
                     <div className="text-yellow-800 font-medium mb-2">

--- a/src/components/training/ContentSection.tsx
+++ b/src/components/training/ContentSection.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import ReactMarkdown, { Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import { SubSectionData, extractSubSections } from '@/utils/parseContentSections';
+
+interface ContentSectionProps {
+  title: string;
+  content: string | null | undefined;
+  className?: string;
+}
+
+// マークダウンコンポーネントの定義
+const markdownComponents: Components = {
+  // 箇条書きスタイリング
+  ul: ({ children, ...props }) => (
+    <ul className="list-disc list-inside space-y-1 mb-2 ml-4" {...props}>
+      {children}
+    </ul>
+  ),
+  li: ({ children, ...props }) => (
+    <li className="text-[#475569] leading-[1.6] font-['Noto_Sans_JP:Regular',_sans-serif] text-lg" {...props}>
+      {children}
+    </li>
+  ),
+  
+  // リンクスタイリング
+  a: ({ href, children, ...props }) => (
+    <a
+      href={href}
+      className="text-blue-600 hover:text-blue-800 underline transition-colors"
+      target={href?.startsWith('http') ? '_blank' : undefined}
+      rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+
+  // 段落スタイリング
+  p: ({ children, ...props }) => (
+    <p className="text-[#475569] leading-[1.6] mb-2 font-['Noto_Sans_JP:Regular',_sans-serif] text-lg" {...props}>
+      {children}
+    </p>
+  ),
+
+  // インラインコードスタイリング
+  code: ({ children, ...props }) => (
+    <code className="bg-gray-100 px-2 py-1 rounded text-sm font-mono" {...props}>
+      {children}
+    </code>
+  ),
+
+  // 画像スタイリング
+  img: ({ src, alt, ...props }) => (
+    <img 
+      src={src} 
+      alt={alt || ""} 
+      className="w-full rounded-2xl lg:rounded-[20px] mb-4" 
+      {...props} 
+    />
+  )
+};
+
+// BlockText コンポーネント（セクションタイトル）
+const BlockText: React.FC<{ title: string }> = ({ title }) => {
+  return (
+    <div
+      className="box-border content-stretch flex flex-col gap-2 items-start justify-start leading-[0] p-0 relative shrink-0 text-[#1d382f] text-center tracking-[1px] w-full"
+      data-name="block-Text"
+    >
+      <div className="flex flex-col font-rounded-mplus font-bold justify-center relative shrink-0 text-lg md:text-xl lg:text-[24px] w-full">
+        <h2 className="block leading-[1.6] text-[20px] mt-2 -mb-2 md:text-[20px] md:mt-2 md:-mb-2 lg:text-[24px] lg:mt-0 lg:mb-0">{title}</h2>
+      </div>
+    </div>
+  );
+};
+
+// SubSection コンポーネント（黒丸アイコン付きサブセクション）
+const SubSection: React.FC<{ title: string; content: string | null | undefined }> = ({ title, content }) => {
+  return (
+    <div className="box-border content-stretch flex flex-row gap-4 items-start justify-start p-0 relative shrink-0 w-full">
+      {/* 黒丸アイコン */}
+      <div className="flex items-center justify-center relative shrink-0 mt-2.5">
+        <div 
+          className="bg-[#0d221d] h-2.5 rounded-full relative shrink-0 w-2.5" 
+          data-name="black-dot"
+        />
+      </div>
+      
+      {/* サブセクション内容 */}
+      <div className="box-border content-stretch flex flex-col gap-3 items-start justify-start p-0 relative shrink-0 flex-1 min-w-0">
+        {/* サブセクションタイトル */}
+        <div className="font-rounded-mplus font-bold leading-[0] not-italic relative shrink-0 text-base md:text-lg lg:text-[18px] text-[#1d382f] text-left break-words">
+          <h3 className="block leading-[1.6] break-words">{title}</h3>
+        </div>
+        
+        {/* サブセクション本文 */}
+        {(() => {
+          if (!content || typeof content !== 'string') {
+            return (
+              <div className="text-gray-400 text-sm italic">
+                サブセクションのコンテンツがありません
+              </div>
+            );
+          }
+          
+          const trimmedContent = content.trim();
+          if (!trimmedContent) {
+            return null; // 空のコンテンツは表示しない
+          }
+          
+          return (
+            <div className="font-['Noto_Sans_JP:Regular',_sans-serif] font-normal leading-[0] not-italic relative shrink-0 text-lg text-[#475569] text-left">
+              <ReactMarkdown 
+                components={markdownComponents}
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeHighlight]}
+              >
+                {trimmedContent}
+              </ReactMarkdown>
+            </div>
+          );
+        })()}
+      </div>
+    </div>
+  );
+};
+
+// 区切り線コンポーネント
+const SectionDivider: React.FC = () => {
+  return (
+    <div className="h-0 relative shrink-0 w-full">
+      <div
+        className="absolute bottom-0 left-0 right-0 top-[-2px]"
+        style={{ "--stroke-0": "rgba(51, 65, 85, 1)" } as React.CSSProperties}
+      >
+        <svg
+          className="block size-full"
+          fill="none"
+          preserveAspectRatio="none"
+          role="presentation"
+          viewBox="0 0 628 2"
+        >
+          <line
+            id="Line 5"
+            stroke="var(--stroke-0, #334155)"
+            strokeDasharray="1 12"
+            strokeLinecap="round"
+            strokeWidth="2"
+            x1="1"
+            x2="627"
+            y1="1"
+            y2="1"
+          />
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+// メインのContentSectionコンポーネント（白い丸角ボックス）
+const ContentSection: React.FC<ContentSectionProps> = ({ 
+  title, 
+  content, 
+  className = "" 
+}) => {
+  // Step 3で黒丸アイコン付きサブセクション実装完了
+  console.log('📦 ContentSection レンダリング:', { title, contentLength: content?.length });
+
+  return (
+    <div
+      className={`bg-[#ffffff] relative rounded-[40px] lg:rounded-[56px] shrink-0 w-full ${className}`}
+      data-name={`##${title}`}
+    >
+      <div className="absolute border-2 border-[#000000] border-solid inset-0 pointer-events-none rounded-[40px] lg:rounded-[56px]" />
+      <div className="flex flex-col items-center relative size-full">
+        <div className="box-border content-stretch flex flex-col gap-8 items-center justify-start p-6 md:p-10 lg:p-[56px] relative w-full">
+          
+          {/* ヘッダー部分 */}
+          <div
+            className="box-border content-stretch flex flex-col gap-8 items-start justify-center p-0 relative shrink-0 w-full"
+            data-name="Heading-explainBlock"
+          >
+            <div className="box-border content-stretch flex flex-col gap-6 items-start justify-start p-0 relative shrink-0 w-full">
+              <BlockText title={title} />
+            </div>
+            
+            {/* 区切り線 */}
+            <SectionDivider />
+          </div>
+
+          {/* コンテンツ部分（Step 3: サブセクション表示） */}
+          <div
+            className="box-border content-stretch flex flex-col gap-6 items-start justify-center p-0 relative shrink-0 w-full"
+            data-name="lists"
+          >
+            {(() => {
+              // エラーガード: contentが無効な場合
+              if (!content || typeof content !== 'string') {
+                console.warn('ContentSection - 無効なコンテンツ:', { title, content, contentType: typeof content });
+                return (
+                  <div className="text-gray-400 text-sm italic">
+                    コンテンツが利用できません
+                  </div>
+                );
+              }
+
+              const trimmedContent = content.trim();
+              if (!trimmedContent) {
+                return (
+                  <div className="text-gray-400 text-sm italic">
+                    コンテンツが空です
+                  </div>
+                );
+              }
+
+              const subSections = extractSubSections(content);
+              console.log('📄 ContentSection - サブセクション解析:', { title, subSectionCount: subSections.length });
+              
+              if (subSections.length > 0) {
+                return subSections.map((subSection, index) => (
+                  <SubSection 
+                    key={index}
+                    title={subSection.title}
+                    content={subSection.content}
+                  />
+                ));
+              } else {
+                // サブセクションがない場合は通常のコンテンツとして表示
+                return (
+                  <div className="font-['Noto_Sans_JP:Regular',_sans-serif] font-normal leading-[0] not-italic relative shrink-0 text-lg text-[#475569] text-left w-full">
+                    <ReactMarkdown 
+                      components={markdownComponents}
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeHighlight]}
+                    >
+                      {trimmedContent}
+                    </ReactMarkdown>
+                  </div>
+                );
+              }
+            })()
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ContentSection;

--- a/src/components/training/DesignSolutionSection.tsx
+++ b/src/components/training/DesignSolutionSection.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+interface DesignSolutionSectionProps {
+  content: string | null | undefined;
+  className?: string;
+}
+
+// DesignSolutionSection コンポーネント（デザイン解答例セクション用）
+const DesignSolutionSection: React.FC<DesignSolutionSectionProps> = ({ 
+  content, 
+  className = "" 
+}) => {
+  console.log('🎨 DesignSolutionSection レンダリング:', { contentLength: content?.length });
+
+  return (
+    <div
+      className={`bg-[#ffffff] relative rounded-[56px] shrink-0 w-full ${className}`}
+      data-name="design-solution"
+    >
+      <div className="absolute border-2 border-[#000000] border-solid inset-0 pointer-events-none rounded-[56px]" />
+      <div className="flex flex-col items-center relative size-full">
+        <div className="box-border content-stretch flex flex-col gap-8 items-center justify-start p-[56px] relative w-full">
+          
+          {/* ヘッダー部分 */}
+          <div
+            className="box-border content-stretch flex flex-col gap-8 items-start justify-center p-0 relative shrink-0 w-full"
+            data-name="Heading-explainBlock"
+          >
+            <div className="box-border content-stretch flex flex-col gap-6 items-start justify-start p-0 relative shrink-0 w-full">
+              {/* デザイン解答例タイトル */}
+              <div
+                className="box-border content-stretch flex flex-col gap-2 items-start justify-start leading-[0] p-0 relative shrink-0 text-[#0d0f18] text-center tracking-[1px] w-full"
+                data-name="block-Text"
+              >
+                <div
+                  className="flex flex-col font-['Noto_Sans:Display_Regular',_'Noto_Sans_JP:Regular',_sans-serif] font-normal justify-center relative shrink-0 text-[12px] w-full"
+                  style={{ fontVariationSettings: "'CTGR' 100, 'wdth' 100" }}
+                >
+                  <p className="block leading-[1.6]">(解答例)</p>
+                </div>
+                <div className="flex flex-col font-['Noto_Sans_JP:Bold',_sans-serif] font-bold justify-center relative shrink-0 text-[24px] w-full">
+                  <p className="block leading-[1.6]">デザイン解答例</p>
+                </div>
+              </div>
+            </div>
+            
+            {/* 区切り線 */}
+            <div className="h-0 relative shrink-0 w-full">
+              <div
+                className="absolute bottom-0 left-0 right-0 top-[-2px]"
+                style={{ "--stroke-0": "rgba(51, 65, 85, 1)" } as React.CSSProperties}
+              >
+                <svg
+                  className="block size-full"
+                  fill="none"
+                  preserveAspectRatio="none"
+                  role="presentation"
+                  viewBox="0 0 628 2"
+                >
+                  <line
+                    id="Line 5"
+                    stroke="var(--stroke-0, #334155)"
+                    strokeDasharray="1 12"
+                    strokeLinecap="round"
+                    strokeWidth="2"
+                    x1="1"
+                    x2="627"
+                    y1="1"
+                    y2="1"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          {/* デザイン解答例コンテンツ部分 */}
+          <div
+            className="box-border content-stretch flex flex-col gap-6 items-start justify-center p-0 relative shrink-0 w-full"
+            data-name="design-solution-content"
+          >
+            {(() => {
+              // エラーガード: contentが無効な場合
+              if (!content || typeof content !== 'string') {
+                console.warn('DesignSolutionSection - 無効なコンテンツ:', { content, contentType: typeof content });
+                return (
+                  <div className="text-gray-400 text-sm italic">
+                    デザイン解答例のコンテンツが利用できません
+                  </div>
+                );
+              }
+
+              const trimmedContent = content.trim();
+              if (!trimmedContent) {
+                return (
+                  <div className="text-gray-400 text-sm italic">
+                    デザイン解答例のコンテンツが空です
+                  </div>
+                );
+              }
+
+              return (
+                <div className="font-['Noto_Sans_JP:Regular',_sans-serif] font-normal leading-[0] not-italic relative shrink-0 text-[14px] text-[rgba(13,15,24,0.8)] text-left w-full">
+                  <p className="block leading-[1.6] whitespace-pre-wrap">{trimmedContent}</p>
+                </div>
+              );
+            })()}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DesignSolutionSection;

--- a/src/lib/services/training/task-detail.ts
+++ b/src/lib/services/training/task-detail.ts
@@ -141,8 +141,9 @@ export const getTrainingTaskDetail = async (
       taskSlug
     );
 
-    // Edge Function が空コンテンツを返した場合、Sanity から Portable Text セクションを補完
-    if (!taskDetail.content && !taskDetail.sanitySections?.length) {
+    // Sanity の Portable Text セクションを優先描画したいので、sanitySections が空であれば
+    // Edge Function の markdown content が返っていても Sanity から補完する
+    if (!taskDetail.sanitySections?.length) {
       try {
         const sanityData = await getTrainingTaskDetailFromSanity(trainingSlug, taskSlug);
         if (sanityData?.sections?.length) {

--- a/src/utils/parseContentSections.ts
+++ b/src/utils/parseContentSections.ts
@@ -1,0 +1,192 @@
+// content.mdの解析とセクション分割ユーティリティ（構造化データ対応版）
+
+export interface ContentSectionData {
+  title: string;
+  content: string;
+  type: 'regular' | 'design-solution' | 'premium-only';
+}
+
+// フロントマターからの構造化データ型
+export interface StructuredSection {
+  title: string;
+  content: string;
+  type?: 'regular' | 'design-solution' | 'premium-only';
+  subsections?: {
+    title: string;
+    content: string;
+  }[];
+}
+
+export interface SubSectionData {
+  title: string;
+  content: string;
+}
+
+/**
+ * 構造化データを優先して、フォールバックでマークダウン解析を行う
+ */
+export const parseContentSections = (
+  markdown: string | null | undefined,
+  structuredSections?: StructuredSection[]
+): ContentSectionData[] => {
+  // 構造化データが利用可能な場合は優先して使用
+  if (structuredSections && structuredSections.length > 0) {
+    console.log('📋 parseContentSections - 構造化データを使用:', structuredSections);
+    return structuredSections.map(section => ({
+      title: section.title,
+      content: section.content,
+      type: section.type || 'regular'
+    }));
+  }
+
+  // フォールバック: 従来のマークダウン解析
+  console.log('📋 parseContentSections - マークダウン解析にフォールバック');
+  
+  // エラーガード: nullやundefinedの場合は空配列を返す
+  if (!markdown || typeof markdown !== 'string') {
+    console.warn('parseContentSections: 無効なマークダウンコンテンツ:', { markdown, type: typeof markdown });
+    return [];
+  }
+
+  // 空文字列の場合も空配列を返す
+  if (markdown.trim() === '') {
+    console.warn('parseContentSections: 空のマークダウンコンテンツ');
+    return [];
+  }
+
+  const sections: ContentSectionData[] = [];
+  const lines = markdown.split('\n');
+  let currentSection: ContentSectionData | null = null;
+  
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      // 前のセクションを保存
+      if (currentSection) {
+        sections.push(currentSection);
+      }
+      
+      // 新しいセクションを開始
+      const title = line.replace('## ', '').trim();
+      let type: 'regular' | 'design-solution' | 'premium-only' = 'regular';
+      
+      if (title === 'デザイン解答例') {
+        type = 'design-solution';
+      }
+      
+      currentSection = {
+        title,
+        content: '',
+        type
+      };
+    } else if (currentSection) {
+      // PREMIUM_ONLY コメントチェック
+      if (line.includes('<!-- PREMIUM_ONLY -->')) {
+        currentSection.type = 'premium-only';
+      } else {
+        // 現在のセクションにコンテンツを追加
+        currentSection.content += line + '\n';
+      }
+    }
+  }
+  
+  // 最後のセクションを保存
+  if (currentSection) {
+    sections.push(currentSection);
+  }
+  
+  console.log('📋 parseContentSections - 解析結果:', sections);
+  return sections;
+};
+
+/**
+ * セクション内の ### サブセクションを抽出
+ */
+export const extractSubSections = (content: string | null | undefined): SubSectionData[] => {
+  // エラーガード: nullやundefinedの場合は空配列を返す
+  if (!content || typeof content !== 'string') {
+    console.warn('extractSubSections: 無効なコンテンツ:', { content, type: typeof content });
+    return [];
+  }
+
+  // 空文字列の場合も空配列を返す
+  if (content.trim() === '') {
+    return [];
+  }
+
+  const subSections: SubSectionData[] = [];
+  const lines = content.split('\n');
+  let currentSubSection: SubSectionData | null = null;
+  
+  for (const line of lines) {
+    if (line.startsWith('### ')) {
+      // 前のサブセクションを保存
+      if (currentSubSection) {
+        subSections.push(currentSubSection);
+      }
+      
+      // 新しいサブセクションを開始
+      currentSubSection = {
+        title: line.replace('### ', '').trim(),
+        content: ''
+      };
+    } else if (currentSubSection) {
+      // 現在のサブセクションにコンテンツを追加
+      currentSubSection.content += line + '\n';
+    }
+  }
+  
+  // 最後のサブセクションを保存
+  if (currentSubSection) {
+    subSections.push(currentSubSection);
+  }
+  
+  console.log('📋 extractSubSections - サブセクション解析結果:', subSections);
+  return subSections;
+};
+
+/**
+ * マークダウンコンテンツから特定の ## セクションを除去
+ */
+export const removeSection = (markdown: string, sectionTitle: string): string => {
+  const sections = parseContentSections(markdown);
+  const filteredSections = sections.filter(section => section.title !== sectionTitle);
+  
+  return filteredSections
+    .map(section => `## ${section.title}\n${section.content}`)
+    .join('\n');
+};
+
+/**
+ * レッスンカード情報を抽出
+ */
+export interface LessonCardData {
+  title: string;
+  description: string;
+  image?: string;
+  url?: string;
+}
+
+export const extractLessonCard = (content: string): LessonCardData | null => {
+  const lessonCardRegex = /<!-- lesson-card -->([\s\S]*?)<!-- \/lesson-card -->/;
+  const match = content.match(lessonCardRegex);
+  
+  if (match) {
+    const cardContent = match[1];
+    const titleMatch = cardContent.match(/lesson_title:\s*(.+)/);
+    const descriptionMatch = cardContent.match(/lesson_description:\s*(.+)/);
+    const imageMatch = cardContent.match(/lesson_image:\s*(.+)/);
+    const urlMatch = cardContent.match(/lesson_url:\s*(.+)/);
+    
+    const lessonCard = {
+      title: titleMatch?.[1]?.trim() || '',
+      description: descriptionMatch?.[1]?.trim() || '',
+      image: imageMatch?.[1]?.trim(),
+      url: urlMatch?.[1]?.trim()
+    };
+    
+    console.log('📋 extractLessonCard - レッスンカード解析結果:', lessonCard);
+    return lessonCard;
+  }
+  
+  return null;
+};


### PR DESCRIPTION
## 概要
Sanity sections 未移行のトレーニングタスクで、`task.content`（markdown）が生テキストのまま表示されていた問題を修正。main の `TaskDetailPage` と同じセクション分割描画に移植した。

## 変更内容
- **page.tsx**: Markdownフォールバックを `parseContentSections` でセクション分割し、`ContentSection` / `DesignSolutionSection` / プレミアムロックUI で描画（main の TaskDetailPage:377-407 と同構成）
- **task-detail.ts**: `sanitySections` が空なら Edge Function が markdown content を返していても Sanity から補完するよう条件変更
- **新規コンポーネント**: `ContentSection` / `DesignSolutionSection` / `parseContentSections` — main からコピー＋最小の Next.js 適応のみ（react-router-dom → next/link、/training/plan → /subscription、null 安全化）
- **依存追加**: `rehype-highlight`（コードブロックのハイライト）
- **scripts/fix-book-lending-contamination.ts**: book-lending-system の sections が他トレーニングに混入した Sanity データ汚染を修正するスクリプト（dry-run 既定、`--apply` で実適用）

## 確認済み
- [x] main のコンポーネントと diff 突合（Next.js 適応以外は同一）
- [x] `npx tsc --noEmit` パス
- [x] `npm run build` パス
- [ ] ブラウザで main と目視比較（未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)