### PR TITLE
feat: ワークショップヘッダーに「質問する」リンクを追加（BON-133）

### DIFF
--- a/src/components/workshop/WorkshopHeader.tsx
+++ b/src/components/workshop/WorkshopHeader.tsx
@@ -6,13 +6,21 @@ import Image from "next/image";
 export default function WorkshopHeader() {
   return (
     <header className="w-full">
-      <div className="px-5 md:px-6 h-14 flex items-center">
+      <div className="px-5 md:px-6 h-14 flex items-center justify-between">
         <a
           href="https://bo-no.design"
           aria-label="BONO"
           className="inline-flex items-center opacity-100 hover:opacity-70 transition-opacity"
         >
           <Image src="/images/bono-logo.svg" alt="BONO" width={68} height={20} />
+        </a>
+        <a
+          href="https://liveq.page/e2/0c5035efcd6c6bfe4162"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[13px] font-bold font-line-seed-jp text-text-primary border border-border-default rounded-full px-4 py-1.5 hover:bg-base transition-colors"
+        >
+          質問する
         </a>
       </div>
     </header>


### PR DESCRIPTION
当日の質問ページ（LiveQ）へのリンクをヘッダー右端に追加。全ワークショップページ共通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)