### PR TITLE
fix: 意見箱のリンク先をGoogleフォームURLに変更

### DIFF
--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -12,7 +12,8 @@ import { ICON_SIZE } from "./icon-utils";
 import { DirectInbox, Home2 } from "iconsax-react";
 import { Button } from "@/components/ui/button";
 
-const FEEDBACK_URL = "https://forms.gle/Y5LorStnPm4jzFv77";
+const FEEDBACK_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLSfUE-AYkZsepc8NfDGO5FtPnHJI77-iMIMnx6KxSfgWVaUgOA/viewform?usp=header";
 
 /**
  * サイドバーコンポーネント


### PR DESCRIPTION
## Summary
- サイドバーの「意見箱」リンク先を、旧Googleフォーム短縮URL（forms.gle）から新しいGoogleフォームURLに変更

## Test plan
- [x] `npx tsc --noEmit` 通過
- [ ] 実ブラウザでサイドバーの「意見箱」ボタンを押し、正しいフォームが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)