### PR TITLE
掲示板コメントに画像添付(1枚)機能を追加

### DIFF
--- a/src/components/questions/FormattingTextarea.tsx
+++ b/src/components/questions/FormattingTextarea.tsx
@@ -35,6 +35,10 @@ interface FormattingTextareaProps {
   id?: string;
   /** アクセシビリティ用ラベル（ツールバーの説明） */
   ariaLabel?: string;
+  /** 書式ボタン群の右側に薄い区切り線を挟んで追加するボタン（画像添付など） */
+  toolbarExtra?: React.ReactNode;
+  /** 入力エリアとツールバーの間に挿入するコンテンツ（画像添付プレビュー等）。カード内側に収まる */
+  belowContent?: React.ReactNode;
 }
 
 type Tab = "edit" | "preview";
@@ -51,6 +55,8 @@ export function FormattingTextarea({
   className,
   id,
   ariaLabel = "本文",
+  toolbarExtra,
+  belowContent,
 }: FormattingTextareaProps) {
   const [tab, setTab] = useState<Tab>("edit");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -143,6 +149,8 @@ export function FormattingTextarea({
         </div>
       )}
 
+      {belowContent}
+
       {/* フッター: 書式アクションエリア（カードの中に置く） */}
       <div
         className="mt-3 flex items-center justify-between gap-2 border-t border-border/60 pt-2"
@@ -171,6 +179,13 @@ export function FormattingTextarea({
           >
             <List size={16} />
           </ToolbarButton>
+          {toolbarExtra && (
+            <>
+              {/* 書式ボタン群と区別するための薄い縦区切り線 */}
+              <div className="mx-1 h-4 w-px bg-border/60" aria-hidden />
+              {toolbarExtra}
+            </>
+          )}
         </div>
         <div className="flex items-center gap-1 text-[12px]">
           <TabButton active={tab === "edit"} onClick={() => setTab("edit")}>
@@ -185,8 +200,8 @@ export function FormattingTextarea({
   );
 }
 
-/** フッターの ghost アイコンボタン */
-function ToolbarButton({
+/** フッターの ghost アイコンボタン（画像添付ボタン等、toolbarExtra からも再利用する） */
+export function ToolbarButton({
   label,
   onClick,
   disabled,

--- a/src/components/questions/QuestionCommentForm.tsx
+++ b/src/components/questions/QuestionCommentForm.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { FormattingTextarea } from "@/components/questions/FormattingTextarea";
+import { FormattingTextarea, ToolbarButton } from "@/components/questions/FormattingTextarea";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, AlertCircle, ImagePlus, X } from "lucide-react";
 import { validateImageFile, resizeImageToWebP } from "@/lib/image-utils";
@@ -162,6 +162,47 @@ export function QuestionCommentForm({
             disabled={isPending}
             containerClassName="rounded-[24px] border border-border bg-surface px-[21px] pb-[10px] pt-[17px] shadow-[var(--shadow-input)]"
             className="min-h-[48px] text-[16px]"
+            toolbarExtra={
+              // 画像は1枚固定。選択済みのときはボタン自体を隠す（フォーカス不要で常時見える位置）
+              !imagePreviewUrl ? (
+                <ToolbarButton
+                  label="画像を追加"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isBusy}
+                >
+                  {isProcessingImage ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <ImagePlus size={16} />
+                  )}
+                </ToolbarButton>
+              ) : null
+            }
+            belowContent={
+              // プレビューはカード（白背景）の内側・textarea 下に表示する
+              imagePreviewUrl ? (
+                <div className="relative mt-3 w-fit">
+                  {/* プレビューはローカル objectURL。next/image は blob: を扱えないため素の img */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={imagePreviewUrl}
+                    alt="添付画像プレビュー"
+                    className="max-h-[240px] max-w-full rounded-[16px] border border-border object-contain"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleRemoveImage}
+                    disabled={isPending}
+                    aria-label="画像を削除"
+                    className="absolute right-2 top-2 h-8 w-8 rounded-full bg-foreground/70 p-0 text-background hover:bg-foreground hover:text-background"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : null
+            }
           />
 
           {/* 画像入力（隠し要素・ref クリックで開く） */}
@@ -172,30 +213,6 @@ export function QuestionCommentForm({
             className="hidden"
             onChange={handleImageSelect}
           />
-
-          {/* プレビュー（textarea 下・右上に削除ボタン） */}
-          {imagePreviewUrl && (
-            <div className="relative w-fit">
-              {/* プレビューはローカル objectURL。next/image は blob: を扱えないため素の img */}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={imagePreviewUrl}
-                alt="添付画像プレビュー"
-                className="max-h-[240px] max-w-full rounded-[16px] border border-border object-contain"
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={handleRemoveImage}
-                disabled={isPending}
-                aria-label="画像を削除"
-                className="absolute right-2 top-2 h-8 w-8 rounded-full bg-foreground/70 p-0 text-background hover:bg-foreground hover:text-background"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
 
           {/* 入力を始めたらカウンタ＋ボタン行がアニメーション付きで現れる */}
           <div
@@ -208,23 +225,7 @@ export function QuestionCommentForm({
             <div className="min-h-0">
               <div className="flex items-center justify-between gap-2 pt-1">
                 <div className="flex items-center gap-2">
-                  {/* 画像未添付のときだけ追加ボタンを出す（1枚固定） */}
-                  {!imagePreviewUrl && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={isBusy}
-                      aria-label="画像を追加"
-                    >
-                      {isProcessingImage ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <ImagePlus className="h-4 w-4" />
-                      )}
-                    </Button>
-                  )}
+                  {/* 画像追加ボタンは書式ツールバー（textarea下部）に常時表示する */}
                   <span className="text-xs text-muted-foreground">
                     {content.length} / {MAX_LENGTH}
                   </span>

--- a/src/components/questions/QuestionCommentForm.tsx
+++ b/src/components/questions/QuestionCommentForm.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { FormattingTextarea } from "@/components/questions/FormattingTextarea";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Loader2, AlertCircle } from "lucide-react";
+import { Loader2, AlertCircle, ImagePlus, X } from "lucide-react";
+import { validateImageFile, resizeImageToWebP } from "@/lib/image-utils";
+import { uploadQuestionImage } from "@/app/questions/new/actions";
 import { addComment, type QuestionComment } from "@/lib/services/questions";
 
 /** サーバ側・DB と一致させる文字数上限（Figma の 2000 には合わせない） */
@@ -38,8 +40,55 @@ export function QuestionCommentForm({
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  // 文字入力が始まったらボタン行を表示する（focus だけでは出さない）
-  const hasInput = content.length > 0;
+  // 添付画像（1枚固定・任意）。imageBlob: アップロード対象の縮小済み WebP。
+  // imagePreviewUrl: その場プレビュー用 objectURL。
+  const [imageBlob, setImageBlob] = useState<Blob | null>(null);
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
+  const [isProcessingImage, setIsProcessingImage] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // テキスト入力 or 画像選択のどちらかがあればボタン行を表示する
+  const hasInput = content.length > 0 || imagePreviewUrl !== null;
+
+  const handleImageSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // 同じファイルを選び直せるよう input をリセット
+    e.target.value = "";
+    if (!file) return;
+
+    const validation = validateImageFile(file);
+    if (!validation.valid) {
+      setError(validation.error ?? "画像を選択し直してください");
+      return;
+    }
+
+    setError(null);
+    setIsProcessingImage(true);
+    try {
+      const blob = await resizeImageToWebP(file);
+      // 既存プレビューがあれば objectURL を解放してから差し替え
+      if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl);
+      setImageBlob(blob);
+      setImagePreviewUrl(URL.createObjectURL(blob));
+    } catch {
+      setError("画像の処理に失敗しました。別の画像でお試しください");
+    } finally {
+      setIsProcessingImage(false);
+    }
+  };
+
+  const handleRemoveImage = () => {
+    if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl);
+    setImageBlob(null);
+    setImagePreviewUrl(null);
+  };
+
+  const clearForm = () => {
+    setContent("");
+    if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl);
+    setImageBlob(null);
+    setImagePreviewUrl(null);
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -48,17 +97,40 @@ export function QuestionCommentForm({
     if (!trimmed) return;
 
     startTransition(async () => {
-      const result = await addComment({ questionId, questionSlug, content: trimmed });
+      // 画像があれば先にアップロードして公開URLを得る。失敗時は入力・画像を保持したまま中断。
+      let imageUrl: string | undefined;
+      if (imageBlob) {
+        const formData = new FormData();
+        formData.append("file", imageBlob, "attachment.webp");
+        const uploadResult = await uploadQuestionImage(formData);
+        if (uploadResult.error || !uploadResult.imageUrl) {
+          setError(uploadResult.error || "画像の添付に失敗しました");
+          return;
+        }
+        imageUrl = uploadResult.imageUrl;
+      }
+
+      const result = await addComment({
+        questionId,
+        questionSlug,
+        content: trimmed,
+        ...(imageUrl ? { imageUrl } : {}),
+      });
       if (!result.ok) {
+        // 失敗時は入力テキスト・画像プレビューを保持したままエラー表示
         setError(result.error);
         return;
       }
-      setContent("");
+      // 成功時のみテキスト・画像 state をクリア
+      clearForm();
       // 返ってきたコメントを即座に一覧へ反映しつつ、裏でサーバー状態と同期する
       onAdded?.(result.comment);
       router.refresh();
     });
   };
+
+  // 二重送信・処理中はボタンを無効化する
+  const isBusy = isPending || isProcessingImage;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
@@ -91,6 +163,40 @@ export function QuestionCommentForm({
             containerClassName="rounded-[24px] border border-border bg-surface px-[21px] pb-[10px] pt-[17px] shadow-[var(--shadow-input)]"
             className="min-h-[48px] text-[16px]"
           />
+
+          {/* 画像入力（隠し要素・ref クリックで開く） */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="hidden"
+            onChange={handleImageSelect}
+          />
+
+          {/* プレビュー（textarea 下・右上に削除ボタン） */}
+          {imagePreviewUrl && (
+            <div className="relative w-fit">
+              {/* プレビューはローカル objectURL。next/image は blob: を扱えないため素の img */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imagePreviewUrl}
+                alt="添付画像プレビュー"
+                className="max-h-[240px] max-w-full rounded-[16px] border border-border object-contain"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleRemoveImage}
+                disabled={isPending}
+                aria-label="画像を削除"
+                className="absolute right-2 top-2 h-8 w-8 rounded-full bg-foreground/70 p-0 text-background hover:bg-foreground hover:text-background"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+
           {/* 入力を始めたらカウンタ＋ボタン行がアニメーション付きで現れる */}
           <div
             className={`grid overflow-hidden transition-all duration-200 ease-out ${
@@ -101,10 +207,29 @@ export function QuestionCommentForm({
           >
             <div className="min-h-0">
               <div className="flex items-center justify-between gap-2 pt-1">
-                <span className="text-xs text-muted-foreground">
-                  {content.length} / {MAX_LENGTH}
-                </span>
-                <Button type="submit" disabled={isPending || !content.trim()}>
+                <div className="flex items-center gap-2">
+                  {/* 画像未添付のときだけ追加ボタンを出す（1枚固定） */}
+                  {!imagePreviewUrl && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={isBusy}
+                      aria-label="画像を追加"
+                    >
+                      {isProcessingImage ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <ImagePlus className="h-4 w-4" />
+                      )}
+                    </Button>
+                  )}
+                  <span className="text-xs text-muted-foreground">
+                    {content.length} / {MAX_LENGTH}
+                  </span>
+                </div>
+                <Button type="submit" disabled={isBusy || !content.trim()}>
                   {isPending ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/questions/QuestionCommentItem.tsx
+++ b/src/components/questions/QuestionCommentItem.tsx
@@ -167,6 +167,19 @@ export function QuestionCommentItem({
                 containerClassName="rounded-[16px] border border-input bg-surface p-3"
                 className="min-h-[72px]"
               />
+              {/* 編集はテキストのみ。画像は変更UIなしでそのまま表示し続ける（スコープ外） */}
+              {comment.imageUrl && (
+                <div>
+                  {/* 添付画像。Supabase Storage で縮小済みのため素の img で表示 */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={comment.imageUrl}
+                    alt="添付画像"
+                    loading="lazy"
+                    className="max-w-full rounded-[16px] border border-border"
+                  />
+                </div>
+              )}
               {error && <p className="text-xs text-destructive">{error}</p>}
               <div className="flex items-center justify-end gap-2">
                 <Button
@@ -200,6 +213,18 @@ export function QuestionCommentItem({
                 text={comment.content}
                 className="text-[16px] leading-8 text-foreground"
               />
+              {comment.imageUrl && (
+                <div className="mt-3">
+                  {/* 添付画像。Supabase Storage で縮小済みのため素の img で表示 */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={comment.imageUrl}
+                    alt="添付画像"
+                    loading="lazy"
+                    className="max-w-full rounded-[16px] border border-border"
+                  />
+                </div>
+              )}
               {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
 
               {/* フッター：左=リアクション / 右=日付。divider無し（ユーザー指定でFigma 135:4877から変更） */}

--- a/src/lib/services/questions.ts
+++ b/src/lib/services/questions.ts
@@ -20,6 +20,8 @@ export interface QuestionComment {
   authorName: string;
   authorAvatarUrl?: string;
   content: string;
+  /** 添付画像の公開URL（question-attachments バケット、1コメント1枚）。未添付は undefined */
+  imageUrl?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -247,7 +249,7 @@ export async function getQuestionCategories(): Promise<QuestionCategory[]> {
 // ============================================
 
 const COMMENT_COLUMNS =
-  "id, question_id, user_id, author_name, author_avatar_url, content, created_at, updated_at";
+  "id, question_id, user_id, author_name, author_avatar_url, content, image_url, created_at, updated_at";
 
 type CommentRow = {
   id: string;
@@ -256,6 +258,7 @@ type CommentRow = {
   author_name: string;
   author_avatar_url: string | null;
   content: string;
+  image_url: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -268,6 +271,7 @@ function rowToComment(r: CommentRow): QuestionComment {
     authorName: r.author_name,
     authorAvatarUrl: r.author_avatar_url ?? undefined,
     content: r.content,
+    imageUrl: r.image_url ?? undefined,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
@@ -306,6 +310,21 @@ function validateCommentContent(
   return { ok: true, content };
 }
 
+// 添付画像 URL の許可バケット（question/new/actions.ts の ATTACHMENT_BUCKET と一致）
+const ATTACHMENT_BUCKET = "question-attachments";
+
+/**
+ * クライアントから来る画像URLが、自分がアップロードした question-attachments の
+ * 公開URL（`{SUPABASE_URL}/storage/v1/object/public/question-attachments/{uid}/...`）で
+ * あることを検証する。他人のファイルURL・外部URLの注入を防ぐ。
+ */
+function isOwnAttachmentUrl(value: string, userId: string): boolean {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl) return false;
+  const expectedPrefix = `${supabaseUrl}/storage/v1/object/public/${ATTACHMENT_BUCKET}/${userId}/`;
+  return value.startsWith(expectedPrefix);
+}
+
 // 本文プレビュー用に前後空白を除去して指定長でtruncate（末尾に … を付与）
 function truncateForPreview(text: string, maxLength = 300): string {
   const normalized = text.trim();
@@ -318,12 +337,24 @@ async function sendCommentSlackNotification(data: {
   questionSlug: string;
   authorName: string;
   content: string;
+  imageUrl?: string;
 }) {
   const webhookUrl = process.env.SLACK_WEBHOOK_URL;
   if (!webhookUrl) return;
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://app.bo-no.design";
   const questionPageUrl = `${siteUrl}/questions/${data.questionSlug}`;
+
+  // 質問投稿側（api/questions/submit/route.ts の imageBlocks）と同形式の image ブロック
+  const imageBlocks = data.imageUrl
+    ? [
+        {
+          type: "image",
+          image_url: data.imageUrl,
+          alt_text: "添付画像",
+        },
+      ]
+    : [];
 
   const message = {
     blocks: [
@@ -348,6 +379,7 @@ async function sendCommentSlackNotification(data: {
           text: `*コメント内容:*\n${truncateForPreview(data.content)}`,
         },
       },
+      ...imageBlocks,
       {
         type: "actions",
         elements: [
@@ -377,6 +409,7 @@ export async function addComment(input: {
   questionId: string;
   questionSlug: string;
   content: string;
+  imageUrl?: string;
 }): Promise<{ ok: true; comment: QuestionComment } | { ok: false; error: string }> {
   const supabase = await createClient();
   const {
@@ -386,6 +419,12 @@ export async function addComment(input: {
 
   const validated = validateCommentContent(input.content);
   if (!validated.ok) return validated;
+
+  // 画像URLはクライアントから来る文字列。自分がアップロードした
+  // question-attachments の公開URLであることを検証する（外部URL・他人ファイル注入の防止）。
+  if (input.imageUrl && !isOwnAttachmentUrl(input.imageUrl, user.id)) {
+    return { ok: false, error: "画像の添付に失敗しました" };
+  }
 
   // 投稿者プロフィールを auth から snapshot して denormalize
   const authorName =
@@ -403,6 +442,7 @@ export async function addComment(input: {
       author_name: authorName,
       author_avatar_url: authorAvatarUrl,
       content: validated.content,
+      image_url: input.imageUrl ?? null,
     })
     .select(COMMENT_COLUMNS)
     .single();
@@ -426,6 +466,7 @@ export async function addComment(input: {
     questionSlug: input.questionSlug,
     authorName,
     content: validated.content,
+    imageUrl: input.imageUrl,
   });
 
   revalidatePath(`/questions/${input.questionSlug}`);

--- a/supabase/migrations/20260716_add_comment_image_url.sql
+++ b/supabase/migrations/20260716_add_comment_image_url.sql
@@ -1,0 +1,26 @@
+-- =============================================================================
+-- みんなの掲示板：コメントへの画像添付（1コメント1枚）
+-- 作成日: 2026-07-16
+-- 関連: rebono/issues/掲示板：コメントへの画像添付.md (#150)
+-- 設計: 画像は question-attachments バケットにアップロード済みの公開URLを保持する。
+--       真実はこのカラムのみ（Sanity 等には複製しない）。
+--       - 画像のみのコメントは不可（content の NOT NULL / CHECK は変更しない）。
+--       - 編集時の画像変更は今回スコープ外（テキストのみ編集）。
+--       - RLS / View（question_comment_counts）/ レート制限トリガーは変更不要。
+-- NOTE: サーバー側（src/lib/services/questions.ts addComment）でも URL の
+--       ホスト・バケット・所有者プレフィックスを検証する（外部URL注入の防止）。
+-- =============================================================================
+
+ALTER TABLE public.question_comments
+  ADD COLUMN IF NOT EXISTS image_url text;
+
+-- 公開URL長のガード（既存の content CHECK と同じスタイル）
+ALTER TABLE public.question_comments
+  DROP CONSTRAINT IF EXISTS question_comments_image_url_length;
+
+ALTER TABLE public.question_comments
+  ADD CONSTRAINT question_comments_image_url_length
+  CHECK (image_url IS NULL OR char_length(image_url) <= 2048);
+
+COMMENT ON COLUMN public.question_comments.image_url IS
+  '添付画像の公開URL（question-attachments バケット、1コメント1枚、NULL可）。真実はこのカラムのみ';


### PR DESCRIPTION
## Summary
- 質問投稿と同じ基盤(`uploadQuestionImage` / `resizeImageToWebP`)を再利用し、コメントにも画像1枚を添付できるようにする
- `question_comments` に `image_url` カラムを追加。サーバー側で自分がアップロードした `question-attachments` 配下のURLであることを検証してから保存(他人ファイル・外部URL注入の防止)
- 画像のみのコメントは不可(テキスト必須は維持)。編集時の画像変更は今回スコープ外(テキストのみ編集、画像は維持)
- Slack通知(コメント投稿)にも画像ブロックを追加

関連: rebono/issues/掲示板：コメントへの画像添付.md (#150)

## Test plan
- [x] 動作確認済み（AI実施）: `npx tsc --noEmit` / `npm run build` 通過、生hex/rgba直書きなし、RLSがカラム単位制限を持たず新カラムも既存ポリシーで保護されることを確認
- [ ] ユーザーの目視が必要: 画像選択→プレビュー→送信→表示→リロード後表示→編集(画像維持)→削除の一連の動作、モバイル幅での崩れ、Slack通知の画像ブロック表示、非メンバーでのアップロード拒否
  (ローカルSupabase未起動のためAI側では未検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)