### PR TITLE
掲示板一覧・詳細ページの速度改善 + コメント者アイコン表示

### DIFF
--- a/src/__tests__/components/questions/QuestionCard.test.tsx
+++ b/src/__tests__/components/questions/QuestionCard.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { QuestionCard } from "@/components/questions/QuestionCard";
+import type { QuestionListItem } from "@/lib/services/questions";
+import type { Question } from "@/types/sanity";
+
+const baseQuestion = {
+  _id: "q1",
+  title: "テスト質問",
+  slug: { current: "test-q" },
+  publishedAt: "2026-07-01T00:00:00Z",
+  questionContent: [],
+  author: { displayName: "投稿者", avatarUrl: null },
+  category: { _id: "c1", title: "カテゴリ", slug: { current: "cat" } },
+} as unknown as Question;
+
+function makeItem(
+  commenters: QuestionListItem["recentCommenters"],
+  commentCount: number,
+): QuestionListItem {
+  return {
+    question: baseQuestion,
+    commentCount,
+    reactionCounts: { cheer: 0, thanks: 0, insight: 0 },
+    lastActivityAt: "2026-07-01T00:00:00Z",
+    recentCommenters: commenters,
+  };
+}
+
+describe("QuestionCard 直近コメント者アバタースタック", () => {
+  it("メンバー(showEngagement) + コメント者ありでアバタースタックが出る", () => {
+    const { container } = render(
+      <QuestionCard
+        item={makeItem(
+          [
+            { userId: "u1", name: "User1", avatarUrl: "https://ex/1.png" },
+            { userId: "u2", name: "User2", avatarUrl: null },
+            { userId: "u3", name: "User3", avatarUrl: "https://ex/3.png" },
+          ],
+          3,
+        )}
+        showEngagement
+      />,
+    );
+    const stack = container.querySelector(".-space-x-1\\.5");
+    expect(stack).not.toBeNull();
+    // 3人分のアバター（各 size-5）が描画される
+    expect(stack!.querySelectorAll(".size-5").length).toBe(3);
+  });
+
+  it("コメント者が空配列なら何も描画しない", () => {
+    const { container } = render(
+      <QuestionCard item={makeItem([], 0)} showEngagement />,
+    );
+    expect(container.querySelector(".-space-x-1\\.5")).toBeNull();
+  });
+
+  it("非メンバー(showEngagement=false)ではスタックもコメント件数も出ない", () => {
+    const { container, queryByText } = render(
+      <QuestionCard
+        item={makeItem(
+          [{ userId: "u1", name: "User1", avatarUrl: null }],
+          3,
+        )}
+        showEngagement={false}
+      />,
+    );
+    expect(container.querySelector(".-space-x-1\\.5")).toBeNull();
+    expect(queryByText(/コメント/)).toBeNull();
+  });
+});

--- a/src/app/dev/questions-list-before/page.tsx
+++ b/src/app/dev/questions-list-before/page.tsx
@@ -1,0 +1,90 @@
+import { Metadata } from "next";
+import { Card, CardContent } from "@/components/ui/card";
+import { getQuestionList } from "@/lib/services/questions";
+import { getCurrentUser, getSubscriptionStatus } from "@/lib/subscription";
+import { PostQuestionButton } from "@/components/questions/PostQuestionButton";
+import { QuestionCardBefore20260721 } from "@/components/questions/_snapshots/QuestionCardBefore20260721";
+
+/**
+ * /dev/questions-list-before — 掲示板一覧の「変更前」凍結スナップショット（2026-07-21）。
+ * #153（一覧の速度改善 + コメント者アイコン表示）着手前の見た目・データ取得を保存し、
+ * 実装後の /questions といつでも見比べられるようにする。データ取得は実際の
+ * getQuestionList を使うため、着手前の実データがそのまま表示される。
+ * このページは以後も更新しない（比較用の固定リファレンス）。
+ */
+export const metadata: Metadata = {
+  title: "掲示板一覧 変更前スナップショット (/dev/questions-list-before)",
+  robots: { index: false, follow: false },
+};
+
+const LIST_LIMIT = 6;
+
+export default async function Page() {
+  const [items, status, user] = await Promise.all([
+    getQuestionList({ limit: LIST_LIMIT }),
+    getSubscriptionStatus(),
+    getCurrentUser(),
+  ]);
+
+  const hasFullAccess = status.hasMemberAccess;
+  const isLoggedIn = user !== null;
+
+  return (
+    <div className="mx-auto w-full max-w-[1120px] px-4 py-8">
+      <div className="mx-auto mb-8 max-w-[752px] rounded-xl border border-dashed border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+        📌 これは #153（一覧の速度改善＋コメント者アイコン表示）着手前の凍結スナップショットです。
+        本番の見た目とは今後ズレていきます（比較用に固定）。
+      </div>
+
+      <header className="mx-auto flex max-w-[752px] flex-col items-center gap-2 pt-6 text-center">
+        <p className="text-sm text-muted-foreground">Q&amp;A</p>
+        <h1 className="font-rounded-mplus-bold text-4xl text-foreground md:text-5xl">
+          みんなの掲示板
+        </h1>
+        <p className="text-[15px] text-muted-foreground">
+          デザインの話をみんなで広げて深めよう
+        </p>
+        <div className="pt-4">
+          <PostQuestionButton
+            hasMemberAccess={hasFullAccess}
+            isLoggedIn={isLoggedIn}
+            label="スレッドを作成"
+            icon="message-square"
+          />
+        </div>
+      </header>
+
+      <div className="mx-auto mt-8 flex max-w-[752px] flex-col gap-4">
+        {items.map((item) => (
+          <QuestionCardBefore20260721
+            key={item.question._id}
+            item={item}
+            showEngagement={hasFullAccess}
+          />
+        ))}
+
+        {items.length === 0 && (
+          <Card className="rounded-2xl border border-border/60 bg-white">
+            <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+              <div>
+                <p className="text-base font-medium">
+                  最初のスレッドを立ててみよう
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  デザインの気づきや聞いてみたいことを、メンバーと共有できます。
+                </p>
+              </div>
+              <PostQuestionButton
+                hasMemberAccess={hasFullAccess}
+                isLoggedIn={isLoggedIn}
+                variant="secondary"
+                label="スレッドを作成"
+                icon="message-square"
+              />
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/questions/[slug]/page.tsx
+++ b/src/app/questions/[slug]/page.tsx
@@ -159,39 +159,44 @@ export default async function Page({ params }: PageProps) {
   const myCommentReactionsByCommentId: Record<string, ReactionKey[]> = {};
 
   if (hasFullAccess) {
-    comments = await getCommentsByQuestion(question._id);
-
-    // 質問本体のリアクション
-    const qReactionMap = await getReactionCountsMap({
-      targetType: "question",
-      targetIds: [question._id],
-    });
+    // ステージA: コメント取得と「質問本体」に対するリアクション集計・自分の
+    // リアクションを並列で実行する。以前は getCommentsByQuestion →
+    // getReactionCountsMap(質問) → getMyReactions(質問) が直列だったため、
+    // 独立した3クエリが waterfall になっていた（#156）。
+    const [comments_, qReactionMap, qMine] = await Promise.all([
+      getCommentsByQuestion(question._id),
+      getReactionCountsMap({
+        targetType: "question",
+        targetIds: [question._id],
+      }),
+      currentUserId
+        ? getMyReactions({
+            targetType: "question",
+            targetIds: [question._id],
+          })
+        : Promise.resolve([]),
+    ]);
+    comments = comments_;
     questionReactionCounts = qReactionMap[question._id] ?? emptyReactionCounts();
+    myQuestionReactions = qMine.map((r) => r.reaction);
 
-    // コメントのリアクションを 1 クエリで集計
+    // ステージB: コメントの ID が確定してから、コメントに対するリアクション集計と
+    // 自分のリアクションを並列で取得する（コメントが存在する場合のみ）。
     if (comments.length > 0) {
       const commentIds = comments.map((c) => c.id);
-      commentReactionCountsMap = await getReactionCountsMap({
-        targetType: "comment",
-        targetIds: commentIds,
-      });
-    }
-
-    // 自分が押しているリアクション（質問 + コメント）を取得
-    if (currentUserId) {
-      const [qMine, cMine] = await Promise.all([
-        getMyReactions({
-          targetType: "question",
-          targetIds: [question._id],
+      const [cReactionMap, cMine] = await Promise.all([
+        getReactionCountsMap({
+          targetType: "comment",
+          targetIds: commentIds,
         }),
-        comments.length > 0
+        currentUserId
           ? getMyReactions({
               targetType: "comment",
-              targetIds: comments.map((c) => c.id),
+              targetIds: commentIds,
             })
           : Promise.resolve([]),
       ]);
-      myQuestionReactions = qMine.map((r) => r.reaction);
+      commentReactionCountsMap = cReactionMap;
       cMine.forEach((r) => {
         if (!myCommentReactionsByCommentId[r.targetId]) {
           myCommentReactionsByCommentId[r.targetId] = [];

--- a/src/components/questions/QuestionCard.tsx
+++ b/src/components/questions/QuestionCard.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { Heart, Sparkles, ThumbsUp, type LucideIcon } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { extractPreviewText } from "@/lib/portable-text-utils";
 import type { QuestionListItem, ReactionKey } from "@/lib/services/questions";
@@ -8,10 +7,10 @@ import type { QuestionListItem, ReactionKey } from "@/lib/services/questions";
 const PREVIEW_LINES = 4;
 
 /** スタンプ3種の表示定義（ReactionButtons と揃える：cheer=応援 / thanks=いいやん / insight=知りたい） */
-const STAMPS: Array<{ key: ReactionKey; label: string; Icon: LucideIcon }> = [
-  { key: "cheer", label: "応援", Icon: Sparkles },
-  { key: "thanks", label: "いいやん", Icon: ThumbsUp },
-  { key: "insight", label: "知りたい", Icon: Heart },
+const STAMPS: Array<{ key: ReactionKey; label: string; emoji: string }> = [
+  { key: "cheer", label: "応援", emoji: "📣" },
+  { key: "thanks", label: "いいやん", emoji: "👍" },
+  { key: "insight", label: "知りたい", emoji: "🙋" },
 ];
 
 function formatDate(iso?: string): string {
@@ -79,12 +78,14 @@ export function QuestionCard({ item, showEngagement }: QuestionCardProps) {
         <div className="flex flex-wrap items-center justify-between gap-2">
           {/* 左: スタンプ3種（件数>0のもののみ・表示専用）+「・」+ コメント件数（0件のときは非表示） */}
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            {activeStamps.map(({ key, label, Icon }) => (
+            {activeStamps.map(({ key, label, emoji }) => (
               <span
                 key={key}
                 className="flex items-center gap-[6px] rounded-full px-[8.5px] py-[6.5px]"
               >
-                <Icon className="size-3.5 text-muted-foreground" />
+                <span className="text-[14px] leading-none" aria-hidden>
+                  {emoji}
+                </span>
                 <span className="text-xs font-medium text-muted-foreground">
                   {label}
                 </span>

--- a/src/components/questions/ReactionButtons.tsx
+++ b/src/components/questions/ReactionButtons.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Heart, Sparkles, ThumbsUp } from "lucide-react";
 import {
   toggleReaction,
   type ReactionKey,
@@ -10,12 +9,11 @@ import {
 } from "@/lib/services/questions";
 import { cn } from "@/lib/utils";
 
-// 表示名・アイコンは Figma 100:2820 系＋#135 確定に準拠
-// （DBキー cheer/thanks/insight は変更しない）
-const REACTIONS: Array<{ key: ReactionKey; label: string; Icon: typeof Heart }> = [
-  { key: "cheer", label: "応援", Icon: Sparkles },
-  { key: "thanks", label: "いいやん", Icon: ThumbsUp },
-  { key: "insight", label: "知りたい", Icon: Heart },
+// 表示名・絵文字は #153 確定に準拠（DBキー cheer/thanks/insight は変更しない）
+const REACTIONS: Array<{ key: ReactionKey; label: string; emoji: string }> = [
+  { key: "cheer", label: "応援", emoji: "📣" },
+  { key: "thanks", label: "いいやん", emoji: "👍" },
+  { key: "insight", label: "知りたい", emoji: "🙋" },
 ];
 
 interface ReactionButtonsProps {
@@ -92,7 +90,7 @@ export function ReactionButtons({
     size === "sm"
       ? "px-2 py-0.5 gap-1"
       : "px-[13.5px] py-[5.5px] gap-[6px]";
-  const iconSize = size === "sm" ? 12 : 14;
+  const emojiSizeClass = size === "sm" ? "text-[12px]" : "text-[14px]";
 
   const visibleReactions = keys
     ? REACTIONS.filter((r) => keys.includes(r.key))
@@ -100,7 +98,7 @@ export function ReactionButtons({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      {visibleReactions.map(({ key, label, Icon }) => {
+      {visibleReactions.map(({ key, label, emoji }) => {
         const active = optMine.has(key);
         return (
           <button
@@ -122,7 +120,9 @@ export function ReactionButtons({
               pendingKey === key && "opacity-70",
             )}
           >
-            <Icon size={iconSize} />
+            <span className={cn("leading-none", emojiSizeClass)} aria-hidden>
+              {emoji}
+            </span>
             <span>{label}</span>
             <span
               className={cn(

--- a/src/components/questions/_snapshots/QuestionCardBefore20260721.tsx
+++ b/src/components/questions/_snapshots/QuestionCardBefore20260721.tsx
@@ -4,10 +4,15 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { extractPreviewText } from "@/lib/portable-text-utils";
 import type { QuestionListItem, ReactionKey } from "@/lib/services/questions";
 
-/** 一覧カードの本文プレビュー行数（line-clamp-2 と揃える。切れる前提で余裕を持たせる） */
+/**
+ * QuestionCard の凍結スナップショット（2026-07-21・#153着手前）。
+ * 「掲示板一覧の速度改善 + コメント者アイコン表示」実装前の見た目を
+ * /dev/questions-list-before でいつでも見比べられるようにするための複製。
+ * 以降このファイルは更新しない（本体は src/components/questions/QuestionCard.tsx）。
+ */
+
 const PREVIEW_LINES = 4;
 
-/** スタンプ3種の表示定義（ReactionButtons と揃える：cheer=応援 / thanks=いいやん / insight=知りたい） */
 const STAMPS: Array<{ key: ReactionKey; label: string; Icon: LucideIcon }> = [
   { key: "cheer", label: "応援", Icon: Sparkles },
   { key: "thanks", label: "いいやん", Icon: ThumbsUp },
@@ -20,21 +25,16 @@ function formatDate(iso?: string): string {
   return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
 }
 
-interface QuestionCardProps {
+interface QuestionCardBeforeProps {
   item: QuestionListItem;
-  /** コメント数・スタンプ数を表示するか（非メンバーには RLS で 0 が返るため隠す） */
   showEngagement: boolean;
 }
 
-/**
- * 掲示板一覧の投稿カード（Figma: fb-post-card-link-style / node 13:1467）。
- *
- * 構成順: カテゴリタグ → タイトル → アバター+投稿者名 → 本文2行プレビュー → フッター。
- * フッター左はスタンプ3種（件数>0のもののみ・表示専用）+「・」+コメント件数（0件でも常時表示）、右は日付のみ。
- * カード全体が詳細ページへのリンク。
- */
-export function QuestionCard({ item, showEngagement }: QuestionCardProps) {
-  const { question, commentCount, reactionCounts, recentCommenters } = item;
+export function QuestionCardBefore20260721({
+  item,
+  showEngagement,
+}: QuestionCardBeforeProps) {
+  const { question, commentCount, reactionCounts } = item;
   const authorName = question.author?.displayName || "メンバー";
   const authorAvatar = question.author?.avatarUrl;
   const bodyText = extractPreviewText(question.questionContent, PREVIEW_LINES);
@@ -48,14 +48,12 @@ export function QuestionCard({ item, showEngagement }: QuestionCardProps) {
       className="group block w-full rounded-[24px] border border-[var(--card-border-subtle)] bg-surface p-6 shadow-[var(--shadow-board-card)] transition hover:bg-muted/30 hover:shadow-md"
     >
       <div className="flex flex-col gap-4">
-        {/* Content */}
         <div className="flex flex-col gap-3">
           {question.category && (
             <span className="inline-flex w-fit items-center rounded-full bg-[var(--tag-category-bg)] px-[7px] py-[2px] text-xs font-medium text-foreground">
               {question.category.title}
             </span>
           )}
-          {/* Figma 127:3266: M PLUS Rounded 1c SemiBold 16px / leading-6(24px) */}
           <h2 className="font-rounded-mplus text-[16px] font-semibold leading-6 text-foreground transition-colors group-hover:text-primary">
             {question.title}
           </h2>
@@ -75,9 +73,7 @@ export function QuestionCard({ item, showEngagement }: QuestionCardProps) {
           </p>
         </div>
 
-        {/* Footer */}
         <div className="flex flex-wrap items-center justify-between gap-2">
-          {/* 左: スタンプ3種（件数>0のもののみ・表示専用）+「・」+ コメント件数（0件のときは非表示） */}
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             {activeStamps.map(({ key, label, Icon }) => (
               <span
@@ -96,31 +92,11 @@ export function QuestionCard({ item, showEngagement }: QuestionCardProps) {
             {showEngagement && commentCount > 0 && (
               <>
                 {activeStamps.length > 0 && <span aria-hidden>・</span>}
-                {/* 直近コメント者の重なりアバタースタック（最大3人・名前なし・投稿者アバターより小さく区別）。
-                    recentCommenters が空（コメント0件 or 非メンバー）なら描画しない。 */}
-                {recentCommenters.length > 0 && (
-                  <span className="flex -space-x-1.5" aria-hidden>
-                    {recentCommenters.map((c) => (
-                      <Avatar
-                        key={c.userId}
-                        className="size-5 ring-2 ring-surface"
-                      >
-                        {c.avatarUrl && (
-                          <AvatarImage src={c.avatarUrl} alt={c.name} />
-                        )}
-                        <AvatarFallback className="text-[9px]">
-                          {c.name.slice(0, 1)}
-                        </AvatarFallback>
-                      </Avatar>
-                    ))}
-                  </span>
-                )}
                 <span>コメント {commentCount}件</span>
               </>
             )}
           </div>
 
-          {/* 右: 日付のみ */}
           <span className="text-xs text-muted-foreground">
             {formatDate(question.publishedAt)}
           </span>

--- a/src/lib/services/questions.ts
+++ b/src/lib/services/questions.ts
@@ -37,6 +37,15 @@ export interface QuestionListItem {
   reactionCounts: Record<ReactionKey, number>;
   /** publishedAt と最新コメント時刻の遅い方（新着コメントでの浮上ソートに使う） */
   lastActivityAt: string;
+  /**
+   * 直近コメント者（重複除去済み・最新順・最大3人）。カードのアバタースタック表示用。
+   * 非メンバー（未ログイン）は RLS で View が 0 行を返すため空配列になる。コメント0件でも空配列。
+   */
+  recentCommenters: Array<{
+    userId: string;
+    name: string;
+    avatarUrl: string | null;
+  }>;
 }
 
 // ============================================
@@ -54,7 +63,12 @@ export interface QuestionListItem {
  *
  * @param params.limit 最終的に返す件数（デフォルト 20）。互換のため意味は「返す件数」。
  */
-const CANDIDATE_POOL = 50;
+// 表示は最新6件。候補プールはSanity取得＋Supabase集計の転送量に直結するため 20 に抑える（#153）。
+// トレードオフ: last_activity（新着コメント）で浮上させる仕様上、
+// 「publishedAt が候補21件目以降の古いスレッドに新規コメントが付いた」場合、
+// そのスレッドが本来上位に浮上すべきでも候補に入らず取りこぼす可能性がわずかに増える。
+// 表示6件に対し20件の候補があれば実運用上の浮上は十分カバーできると判断（#153）。
+const CANDIDATE_POOL = 20;
 
 /** カード用の共通 projection（QuestionListItem 生成に必要なフィールドを揃える） */
 const QUESTION_CARD_PROJECTION = `{
@@ -75,36 +89,62 @@ const QUESTION_CARD_PROJECTION = `{
  *
  * ※ 並び替えはしない。呼び出し側の要求（浮上ソート／公開日順など）に委ねる。
  */
+/** question_comment_summaries View の recent_commenters jsonb 要素の生の形 */
+type RecentCommenterRow = {
+  user_id: string;
+  author_name: string;
+  author_avatar_url: string | null;
+};
+
 async function buildListItems(questions: Question[]): Promise<QuestionListItem[]> {
   if (questions.length === 0) return [];
 
   const ids = questions.map((q) => q._id);
   const supabase = await createClient();
 
-  const [commentCountsResult, reactionCountsResult, latestCommentResult] =
-    await Promise.all([
-      supabase
-        .from("question_comment_counts")
-        .select("question_id, count")
-        .in("question_id", ids),
-      supabase
-        .from("question_reaction_counts")
-        .select("target_type, target_id, reaction, count")
-        .eq("target_type", "question")
-        .in("target_id", ids),
-      // 質問ごとの最新コメント時刻を JS 側で集計（created_at 降順で取り、最初に出た id を採用）
-      supabase
-        .from("question_comments")
-        .select("question_id, created_at")
-        .in("question_id", ids)
-        .is("deleted_at", null)
-        .order("created_at", { ascending: false }),
-    ]);
+  // コメント集計（数・最新時刻・直近コメント者）は新 View question_comment_summaries に統合し、
+  // リアクション集計は既存 View と合わせて 2 並列で取得する（#153・転送量削減）。
+  const [summaryResult, reactionCountsResult] = await Promise.all([
+    supabase
+      .from("question_comment_summaries")
+      .select("question_id, comment_count, latest_commented_at, recent_commenters")
+      .in("question_id", ids),
+    supabase
+      .from("question_reaction_counts")
+      .select("target_type, target_id, reaction, count")
+      .eq("target_type", "question")
+      .in("target_id", ids),
+  ]);
 
-  const commentMap = new Map<string, number>();
-  (commentCountsResult.data ?? []).forEach((r) =>
-    commentMap.set(r.question_id as string, r.count as number),
-  );
+  // 失敗時は空にフォールバックしページはクラッシュさせない。ただし黙殺せず console.error に残す（#153）。
+  if (summaryResult.error) {
+    console.error("[buildListItems] question_comment_summaries", summaryResult.error);
+  }
+  if (reactionCountsResult.error) {
+    console.error("[buildListItems] question_reaction_counts", reactionCountsResult.error);
+  }
+
+  // 質問ID → 集計（コメント数 / 最新コメント時刻 / 直近コメント者）
+  const summaryMap = new Map<
+    string,
+    {
+      commentCount: number;
+      latestCommentedAt: string | null;
+      recentCommenters: QuestionListItem["recentCommenters"];
+    }
+  >();
+  (summaryResult.data ?? []).forEach((r) => {
+    const rawCommenters = (r.recent_commenters ?? []) as RecentCommenterRow[];
+    summaryMap.set(r.question_id as string, {
+      commentCount: (r.comment_count as number) ?? 0,
+      latestCommentedAt: (r.latest_commented_at as string | null) ?? null,
+      recentCommenters: rawCommenters.map((c) => ({
+        userId: c.user_id,
+        name: c.author_name,
+        avatarUrl: c.author_avatar_url ?? null,
+      })),
+    });
+  });
 
   const reactionMap = new Map<string, Record<ReactionKey, number>>();
   (reactionCountsResult.data ?? []).forEach((r) => {

--- a/src/lib/services/questions.ts
+++ b/src/lib/services/questions.ts
@@ -154,30 +154,22 @@ async function buildListItems(questions: Question[]): Promise<QuestionListItem[]
     reactionMap.set(key, existing);
   });
 
-  // 質問ID → 最新コメント時刻。降順取得なので最初に現れたものが最新。
-  // 取得失敗時（latestCommentResult.data が null）は publishedAt のみでフォールバック。
-  const latestCommentMap = new Map<string, string>();
-  (latestCommentResult.data ?? []).forEach((r) => {
-    const qid = r.question_id as string;
-    if (!latestCommentMap.has(qid)) {
-      latestCommentMap.set(qid, r.created_at as string);
-    }
-  });
-
   return questions.map((q) => {
     const publishedAt = q.publishedAt ?? "";
-    const latestComment = latestCommentMap.get(q._id);
+    const summary = summaryMap.get(q._id);
+    const latestComment = summary?.latestCommentedAt;
     const lastActivityAt =
       latestComment && latestComment > publishedAt ? latestComment : publishedAt;
     return {
       question: q,
-      commentCount: commentMap.get(q._id) ?? 0,
+      commentCount: summary?.commentCount ?? 0,
       reactionCounts: reactionMap.get(q._id) ?? {
         cheer: 0,
         thanks: 0,
         insight: 0,
       },
       lastActivityAt,
+      recentCommenters: summary?.recentCommenters ?? [],
     };
   });
 }

--- a/src/lib/services/questions.ts
+++ b/src/lib/services/questions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getCachedUser } from "@/lib/supabase/server";
 import { client as getClient } from "@/lib/sanity";
 import { revalidatePath } from "next/cache";
 import type { Question, QuestionCategory } from "@/types/sanity";
@@ -596,9 +596,9 @@ export async function getMyReactions(input: {
 }): Promise<Array<{ targetId: string; reaction: ReactionKey }>> {
   if (input.targetIds.length === 0) return [];
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // auth.getUser() はリクエストスコープでキャッシュ済み（質問用・コメント用の
+  // getMyReactions 2回や getSubscriptionStatus 等との認証往復の重複を排除）
+  const user = await getCachedUser();
   if (!user) return [];
 
   const { data } = await supabase

--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -5,7 +5,7 @@ import 'server-only'
  *
  * クライアントコンポーネントからは @/lib/subscription-utils を使用すること
  */
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getCachedUser } from "@/lib/supabase/server";
 import type { PlanType, SubscriptionState } from "@/types/subscription";
 
 // ユーティリティ関数・定数を re-export（Server Component の既存importを壊さない）
@@ -37,14 +37,9 @@ export type {
 export async function getSubscriptionStatus(): Promise<SubscriptionState> {
   const supabase = await createClient();
 
-  let user = null;
-  try {
-    const result = await supabase.auth.getUser();
-    user = result.data.user;
-  } catch {
-    // セッションがstale等で auth が落ちた場合は未ログイン扱い
-    user = null;
-  }
+  // auth.getUser() はリクエストスコープでキャッシュ済み（getCurrentUser 等との
+  // 認証往復の重複を排除。詳細は supabase/server.ts の getCachedUser）
+  const user = await getCachedUser();
 
   if (!user) {
     return {
@@ -121,13 +116,7 @@ export async function getSubscriptionStatus(): Promise<SubscriptionState> {
  * サーバーサイドでユーザー情報を取得
  */
 export async function getCurrentUser() {
-  const supabase = await createClient();
-  try {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    return user;
-  } catch {
-    return null;
-  }
+  // auth.getUser() をリクエストスコープでキャッシュ（getSubscriptionStatus 等との
+  // 認証往復の重複を排除。詳細は supabase/server.ts の getCachedUser）
+  return getCachedUser();
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,8 @@
 import 'server-only'
+import { cache } from 'react'
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import type { User } from '@supabase/supabase-js'
 
 export async function createClient() {
   const cookieStore = await cookies()
@@ -28,3 +30,28 @@ export async function createClient() {
     }
   )
 }
+
+/**
+ * リクエストスコープでメモ化した auth.getUser()。
+ *
+ * 掲示板詳細ページでは getSubscriptionStatus / getCurrentUser / getMyReactions が
+ * それぞれ独立に supabase.auth.getUser() を呼んでおり、1リクエストで最大4回
+ * 認証往復が発生していた（waterfall の一因）。React の cache() でラップすることで
+ * 同一 Server Component レンダー内では初回のみ実行し、2回目以降はキャッシュを返す。
+ *
+ * 注意: これは React の cache()（リクエストごとにリセットされ、ユーザー間で共有され
+ * ない）であり、Next.js の unstable_cache（デプロイ全体で共有）とは別物。したがって
+ * 別ユーザーのリクエスト間でユーザー情報が漏洩することはない。
+ */
+export const getCachedUser = cache(async (): Promise<User | null> => {
+  const supabase = await createClient()
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    return user
+  } catch {
+    // セッションが stale 等で auth が落ちた場合は未ログイン扱い
+    return null
+  }
+})

--- a/supabase/migrations/20260721_create_question_comment_summaries.sql
+++ b/supabase/migrations/20260721_create_question_comment_summaries.sql
@@ -1,0 +1,101 @@
+-- =============================================================================
+-- みんなの掲示板：一覧用コメント集計View（#153）
+-- 作成日: 2026-07-21
+-- 関連: rebono/issues/掲示板：一覧の速度改善とコメント者アイコン表示.md (#153)
+-- 目的: 一覧カードで使う「コメント数・最新コメント時刻・直近コメント者（最大3人）」を
+--       1本のViewにまとめ、Supabaseへの3クエリ（comment_counts / 全コメント行取得）を
+--       1クエリに統合して転送量を削減する。
+-- 前提: 20260622_create_question_comments_and_reactions.sql の question_comment_counts /
+--       question_reaction_counts と同じく WITH (security_invoker = true) を付与し、
+--       ベーステーブル question_comments の RLS（メンバーのみSELECT可）をそのまま伝播させる。
+--       → 非メンバー / 未ログインでは 0 行になり、コメント者アイコンも出ない。
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- question_comment_summaries：質問ごとの集計 + 直近コメント者（重複除去・最大3人）
+-- 出力列:
+--   question_id          : Sanity 質問 _id
+--   comment_count        : 論理削除を除いたコメント数
+--   latest_commented_at  : 最新コメントの created_at（浮上ソート用）
+--   recent_commenters    : 直近コメント者の jsonb 配列（最新順・同一ユーザーは1件に集約・最大3人）
+--                          各要素 = { "user_id": ..., "author_name": ..., "author_avatar_url": ... }
+--
+-- 実装: window関数2段。
+--   1) dedup CTE: PARTITION BY (question_id, user_id) ORDER BY created_at DESC で
+--      同一ユーザーの最新コメント1件だけに絞る（重複除去）。
+--   2) ranked CTE: 絞り込んだ行を PARTITION BY question_id ORDER BY created_at DESC で
+--      rank付けし、rank <= 3 のみ jsonb_agg（created_at 昇順で agg し、配列先頭が最新になるよう
+--      ranked では DESC の rank を採用）。
+--   ※ DISTINCT ON 単独では「質問ごとに複数人」を1行に畳めないため使わない。
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE VIEW public.question_comment_summaries
+WITH (security_invoker = true) AS
+WITH dedup AS (
+  -- 同一 (question_id, user_id) は最新コメント1件のみに絞る（重複除去）
+  SELECT
+    question_id,
+    user_id,
+    author_name,
+    author_avatar_url,
+    created_at,
+    row_number() OVER (
+      PARTITION BY question_id, user_id
+      ORDER BY created_at DESC
+    ) AS rn_user
+  FROM public.question_comments
+  WHERE deleted_at IS NULL
+),
+ranked AS (
+  -- 各質問内で最新コメント順にランク付け（重複除去済みユーザーに対して）
+  SELECT
+    question_id,
+    user_id,
+    author_name,
+    author_avatar_url,
+    created_at,
+    row_number() OVER (
+      PARTITION BY question_id
+      ORDER BY created_at DESC
+    ) AS rn_question
+  FROM dedup
+  WHERE rn_user = 1
+),
+counts AS (
+  -- コメント数と最新コメント時刻（重複除去前の全行が対象）
+  SELECT
+    question_id,
+    count(*)::int AS comment_count,
+    max(created_at) AS latest_commented_at
+  FROM public.question_comments
+  WHERE deleted_at IS NULL
+  GROUP BY question_id
+),
+top_commenters AS (
+  -- 上位3人を最新順（rn_question 昇順）で jsonb 配列に集約。配列先頭が最新コメント者。
+  SELECT
+    question_id,
+    jsonb_agg(
+      jsonb_build_object(
+        'user_id', user_id,
+        'author_name', author_name,
+        'author_avatar_url', author_avatar_url
+      )
+      ORDER BY rn_question
+    ) AS recent_commenters
+  FROM ranked
+  WHERE rn_question <= 3
+  GROUP BY question_id
+)
+SELECT
+  c.question_id,
+  c.comment_count,
+  c.latest_commented_at,
+  COALESCE(t.recent_commenters, '[]'::jsonb) AS recent_commenters
+FROM counts c
+LEFT JOIN top_commenters t ON t.question_id = c.question_id;
+
+COMMENT ON VIEW public.question_comment_summaries IS
+  '質問ごとのコメント数 / 最新コメント時刻 / 直近コメント者（重複除去・最新順・最大3人のjsonb配列）。一覧カード用（#153）';
+
+-- View自体はベーステーブルの RLS が伝播するため authenticated に grant（既存Viewと同じパターン）
+GRANT SELECT ON public.question_comment_summaries TO authenticated;


### PR DESCRIPTION
## Summary
- **一覧(#153)**: `/questions` のSupabase 3クエリを新View `question_comment_summaries` +既存Viewの2並列に統合し転送量を削減。同Viewから直近コメント者（重複除去・最大3人）も取得し、カードのフッターに小さな重なりアバタースタックとして表示。`CANDIDATE_POOL`を50→20に削減
- **詳細(#156)**: `/questions/[slug]` でメンバー閲覧時に最大4回発生していた `auth.getUser()` の重複呼び出しを `React.cache()` でリクエストスコープにメモ化し実質1回に削減。コメント・リアクション取得の4段直列を2ステージ（Promise.all）に並列化

## 非スコープ（次の一手として issue に記録済み）
- 詳細ページのSuspenseストリーミング表示（本文を先に出しコメント欄を後から流し込む）
- Supabase RPCへのさらなる統合
- どちらも今回の改善の効果測定後に判断

## Test plan
- [x] 動作確認済み（AI実施）: `npx tsc --noEmit` / `npm run build` / `npm run lint` / `npx vitest run` 通過。一覧のアバタースタックは実ブラウザ（member1〜3の3アカウント）で1人・3人の重なり表示を確認済み、テストデータはクリーンアップ済み
- [ ] ユーザーの目視が必要: 詳細ページの体感速度（before/after）、一覧・詳細ともにモバイル幅での崩れがないか
- [ ] 本番反映時: `supabase/migrations/20260721_create_question_comment_summaries.sql` の `db push` を先に実行してからデプロイすること（View作成前にコードだけ反映すると集計が壊れる）

関連: rebono/issues/掲示板：一覧の速度改善とコメント者アイコン表示.md (#153) / rebono/issues/掲示板：詳細ページの読み込み速度改善.md (#156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)