### PR TITLE
perf: 掲示板一覧のSanity転送量削減（questionContent先頭8ブロックのみ取得）

### DIFF
--- a/src/lib/services/questions.ts
+++ b/src/lib/services/questions.ts
@@ -73,12 +73,14 @@ export interface QuestionListItem {
 const CANDIDATE_POOL = 20;
 
 /** カード用の共通 projection（QuestionListItem 生成に必要なフィールドを揃える） */
+// questionContent はカードでは extractPreviewText で先頭4行しか使わないため、
+// 全文転送を避け先頭8ブロックのみ取得する（本文が長いスレッドほど転送量削減効果が大きい。#153）。
 const QUESTION_CARD_PROJECTION = `{
     _id,
     title,
     slug,
     publishedAt,
-    questionContent,
+    "questionContent": questionContent[0...8],
     figmaUrl,
     author,
     category->{_id, title, slug}


### PR DESCRIPTION
## Summary
- `/questions` 一覧カードの `questionContent`（Portable Text）を全文取得していたが、実際には `extractPreviewText` で先頭4行しか使っていなかった
- GROQ側で `questionContent[0...8]` に制限し、本文が長いスレッドほど無駄な転送を削減
- 実データ検証: 20件取得時 5149B → 3210B（約38%削減）

## Test plan
- [x] 動作確認済み（AI実施）: `npx tsc --noEmit` / `npm run build` / `npx vitest run` 通過（既存のBlogCard.test.tsx 3件失敗は本変更と無関係）。実データでプレビューに必要なテキストブロックが先頭8ブロック内に収まることを確認
- [ ] ユーザーの目視が必要: 本番反映後、一覧カードの本文プレビューが崩れていないか

関連: rebono/issues/掲示板：一覧の速度改善とコメント者アイコン表示.md (#153)

🤖 Generated with [Claude Code](https://claude.com/claude-code)