### PR TITLE
/top を新トップ構成に差し替え（ログイン中でも新トップ表示）

### DIFF
--- a/src/app/top/page.tsx
+++ b/src/app/top/page.tsx
@@ -1,33 +1,172 @@
 import type { Metadata } from "next";
-import { getAllRoadmaps, getAllLessons } from "@/lib/sanity";
-import TopPageClient from "@/components/top/TopPageClient";
 import { generateWebSiteJsonLd, jsonLdScriptProps } from "@/lib/jsonld";
-
-// ISR: 1時間キャッシュ（Sanityコンテンツは頻繁に変わらない）
-export const revalidate = 3600;
+import { HeroSection } from "@/components/top-next/organisms/HeroSection";
+import { PurposeNav } from "@/components/top-next/organisms/PurposeNav";
+import { FeaturedSeries } from "@/components/top-next/organisms/FeaturedSeries";
+import { NewContentSection } from "@/components/top-next/organisms/NewContentSection";
+import { TrainingSection } from "@/components/top-next/organisms/TrainingSection";
+import { CareerSection } from "@/components/top-next/organisms/CareerSection";
+import { GuideSection } from "@/components/top-next/organisms/GuideSection";
+import LessonHighlightSection, {
+  type LessonHighlightRow,
+} from "@/components/top/home/LessonHighlightSection";
+import AchievementHighlightSection from "@/components/top/home/AchievementHighlightSection";
+import {
+  getAllLessonsWithArticleIds,
+  getAchievementGroups,
+  getLatestMixedContent,
+  getAllGuidesFromSanity,
+} from "@/lib/sanity";
+import { getSubscriptionStatus } from "@/lib/subscription";
 
 export const metadata: Metadata = {
   title: "BONO - UIUXデザインを学ぶ",
   description:
     "UIUXデザインを体系的に学べるオンライン学習プラットフォーム。ロードマップ、レッスン、記事で効率的にスキルアップ。未経験からUIUXデザイナーへ。",
+  // `/` と同一内容のため重複コンテンツを避ける（正規URLは / 、/top はインデックスさせない）
+  alternates: { canonical: "/" },
+  robots: { index: false, follow: true },
 };
 
 /**
  * トップページ（/top）
  *
- * mainと同じ: ログイン状態に関係なくトップページを表示する。
- * サイドナビの「トップ」リンクからアクセス。
+ * 本番トップ `/` と同一の新トップ構成を表示する。`/` はログイン済みを /mypage へ
+ * リダイレクトするため、ログイン中でも新トップを確認・利用できるURLとして /top を
+ * 用意する（リダイレクトなし）。会員（standard/feedback）はヒーローの入会CTAを非表示。
+ * 重複コンテンツ回避のため canonical=/ + noindex。
  */
 export default async function TopPage() {
-  const [roadmaps, lessons] = await Promise.all([
-    getAllRoadmaps(),
-    getAllLessons(),
-  ]);
+  const [allLessons, achievementGroups, newContentItems, allGuides, subscription] =
+    await Promise.all([
+      getAllLessonsWithArticleIds(),
+      getAchievementGroups(3),
+      getLatestMixedContent(4),
+      getAllGuidesFromSanity(),
+      getSubscriptionStatus(),
+    ]);
+  const isMember = subscription.hasMemberAccess;
+
+  const findLesson = (title: string) =>
+    allLessons.find((lesson) => lesson.title === title);
+  const findGuideBySlug = (slug: string) =>
+    allGuides.find((guide) => guide.slug === slug);
+
+  const guideItems = [
+    {
+      title: "デザインとは何か。AIで変わること変わらないこと",
+      description: "見た目ではなくAI時代に必要なスキルを解説",
+      slug: "ai-design-experience-shift",
+    },
+    {
+      title: "ジュニアUI/UXデザイナーのためのスキルマップ",
+      description: "肩書ではなく、何に貢献するかからスキルを考える",
+      slug: "uiuxdesigner-skillmap",
+    },
+    {
+      title: "転職ポートフォリオのポイント",
+      description: "作るだけでなく、採用でアピールすべきポイントを解説",
+      slug: "portfolio-01",
+    },
+    {
+      title: "初心者が身につけるべきUXスキルの全体像",
+      description: "事業やユーザーへの貢献は課題を知ることから",
+      slug: "uxresearch_and_uidesign",
+    },
+  ].map((item) => ({
+    title: item.title,
+    description: item.description,
+    href: `/guide/${item.slug}`,
+    image: findGuideBySlug(item.slug)?.thumbnailUrl,
+  }));
+
+  const lessonRows: LessonHighlightRow[] = [
+    {
+      subheading: "基本のデザインフローを身につける",
+      lessons: [
+        findLesson("ゼロからはじめるUI情報設計"),
+        findLesson("UIが上手くなる人の“デザインサイクル” ─ 入門編β"),
+        findLesson("顧客体験デザインの基本"),
+      ].filter((lesson): lesson is NonNullable<typeof lesson> => Boolean(lesson)),
+    },
+    {
+      subheading: "UIデザインをはじめる",
+      lessons: [
+        findLesson("Figmaの使い方入門"),
+        findLesson("ゼロからはじめるUIビジュアル"),
+        findLesson("センスを盗む技術"),
+      ].filter((lesson): lesson is NonNullable<typeof lesson> => Boolean(lesson)),
+    },
+  ];
+
+  const featuredCards = [
+    {
+      title: "AIにUIデザインの見た目をサポートしてもらう方法",
+      desc: "ユーザー中心のUI設計を学ぶロードマップ",
+      href: "/lessons/ai-ui-styling-beginner",
+      image: "/images/top5/thumbnail-aiui.jpg",
+    },
+    {
+      title: "正解に辿り着くためのデザインワークフローを習得",
+      desc: "基本のワークフローでアウトプットの質を高めます",
+      href: "/lessons/ui-design-flow-lv1",
+      image: "/images/top5/container-uicycle.jpg",
+    },
+    {
+      title: "モードやアクションなどUIデザインの基本を習得",
+      desc: "モード、アクションなど操作UIの基本を学ぼう",
+      href: "/lessons/ui-layout-basic",
+      image: "/images/top5/thumbnail-uihimitsu.jpg",
+    },
+  ];
+
+  const newContentArticles = newContentItems.map((item) => ({
+    category: item.type,
+    title: item.title,
+    href: item.href,
+    image: item.thumbnail || undefined,
+  }));
 
   return (
     <>
       <script {...jsonLdScriptProps(generateWebSiteJsonLd())} />
-      <TopPageClient roadmaps={roadmaps} lessons={lessons} />
+      <HeroSection isMember={isMember} />
+      {/* スマホ(sm未満)のみ PurposeNav と FeaturedSeries の並びを逆にする。
+          sm以上は PurposeNav → FeaturedSeries の元の順序を維持 */}
+      <div className="flex flex-col">
+        <div className="order-2 sm:order-1">
+          <PurposeNav />
+        </div>
+        <div className="order-1 sm:order-2">
+          <FeaturedSeries cards={featuredCards} />
+        </div>
+      </div>
+      <NewContentSection articles={newContentArticles} />
+      <TrainingSection
+        image1="/images/top5/training-info-architecture.jpg"
+        image2="/images/top5/training-ux-research.jpg"
+      />
+      <CareerSection
+        image1="/images/top5/career-uiux-roadmap.jpg"
+        image2="/images/top5/career-uiux-guide.jpg"
+      />
+      <GuideSection guides={guideItems} />
+      <div className="container">
+        <div className="flex flex-col">
+          <LessonHighlightSection
+            compact
+            badgeLabel="レッスン"
+            heading="1−2週間でレベルを上げる"
+            rows={lessonRows}
+            viewAllHref="/lessons"
+          />
+          <AchievementHighlightSection
+            compact
+            storyItems={achievementGroups.stories}
+            outputItems={achievementGroups.outputs}
+          />
+        </div>
+      </div>
     </>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -79,9 +79,9 @@ export function Layout({ children, className, user }: LayoutProps) {
   // /dev/top6: 背景白 + サイドバー右端に薄いボーダーのパターン確認用（このページのみの見た目差分）
   const isTop6 = pathname?.startsWith("/dev/top6") ?? false;
   const isTop5 = pathname?.startsWith("/dev/top5") ?? false;
-  // 本番トップ `/`（新トップ = 旧 /dev/top5 の構成）
-  const isHome = pathname === "/";
-  // `/`, /dev/top5, /dev/top6: ヘッダーグラデーションの高さを半分にする（新トップの見た目）
+  // 本番トップ `/` と、ログイン中でも新トップを見られる /top（同一構成）
+  const isHome = pathname === "/" || pathname === "/top";
+  // `/`, /top, /dev/top5, /dev/top6: ヘッダーグラデーションの高さを半分にする（新トップの見た目）
   const isHalfGradient = isHome || isTop5 || isTop6;
 
   return (


### PR DESCRIPTION
`/` はログイン済みを /mypage へリダイレクトするため、ログイン中に新トップを確認・利用できるURLとして `/top` を新トップ構成に差し替え。

- リダイレクトなし。会員はHero入会CTA非表示
- `/` と同一内容のため canonical=`/` + noindex（重複コンテンツ回避）
- Layout: `/top` を half-gradient に追加

検証: tsc緑 / build緑 / dev の /top が新デザイン

🤖 Generated with [Claude Code](https://claude.com/claude-code)