### PR TITLE
perf: /lessons 一覧の重クエリ撲滅 + 詳細のN+1進捗取得を解消

### DIFF
--- a/src/app/lessons/LessonCardRenderer.tsx
+++ b/src/app/lessons/LessonCardRenderer.tsx
@@ -6,11 +6,12 @@
  */
 
 import Link from "next/link";
-import { urlFor, type LessonWithArticleIds } from "@/lib/sanity";
+import { urlFor } from "@/lib/sanity";
+import type { Lesson } from "@/types/sanity";
 import { LessonCard } from "@/components/lessons/LessonCard";
 
 interface LessonCardRendererProps {
-  lesson: LessonWithArticleIds & { index?: number };
+  lesson: Lesson & { index?: number };
 }
 
 /**

--- a/src/app/lessons/[slug]/page.tsx
+++ b/src/app/lessons/[slug]/page.tsx
@@ -73,19 +73,26 @@ export default async function LessonPage({ params }: PageProps) {
   let totalCompleted = 0;
   let totalArticles = 0;
 
-  // 各クエストの進捗を取得
+  // 全クエストの記事IDを一括収集し、進捗を1回だけ取得（N+1 の直列待ちを回避）
+  const allArticleIds = (lesson.quests || []).flatMap(
+    (q) => q.articles?.map((a) => a._id) || []
+  );
+  const progress = await getLessonProgress(lesson._id, allArticleIds);
+  const completedSet = new Set(progress.completedArticleIds);
+
+  // クエストごとの内訳はローカルで計算（await なし）
   for (const quest of lesson.quests || []) {
-    const articleIds = quest.articles?.map(a => a._id) || [];
-    const progress = await getLessonProgress(lesson._id, articleIds);
+    const qArticleIds = quest.articles?.map((a) => a._id) || [];
+    const completedIds = qArticleIds.filter((id) => completedSet.has(id));
 
     questProgressMap[quest._id] = {
-      completed: progress.completedArticles,
-      total: progress.totalArticles,
-      completedArticleIds: progress.completedArticleIds,
+      completed: completedIds.length,
+      total: qArticleIds.length,
+      completedArticleIds: completedIds,
     };
 
-    totalCompleted += progress.completedArticles;
-    totalArticles += progress.totalArticles;
+    totalCompleted += completedIds.length;
+    totalArticles += qArticleIds.length;
   }
 
   // 全体の進捗率を計算

--- a/src/app/lessons/category/[categoryId]/page.tsx
+++ b/src/app/lessons/category/[categoryId]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getAllLessonsWithArticleIds } from "@/lib/sanity";
+import { getAllLessons } from "@/lib/sanity";
 import PageHeader from "@/components/common/PageHeader";
 import SectionHeading from "@/components/common/SectionHeading";
 import DottedDivider from "@/components/common/DottedDivider";
@@ -47,7 +47,7 @@ export default async function CategoryPage({ params }: PageProps) {
     notFound();
   }
 
-  const lessons = await getAllLessonsWithArticleIds();
+  const lessons = await getAllLessons();
 
   // セクション・サブセクションごとにグルーピング（共通ロジック使用）
   const groupedLessons = groupLessonsNested(lessons);

--- a/src/app/lessons/grouping.ts
+++ b/src/app/lessons/grouping.ts
@@ -9,7 +9,7 @@
  * - categoryTitle/categoryTitles → tags[] でカテゴリマッチング
  */
 
-import type { LessonWithArticleIds } from "@/lib/sanity";
+import type { Lesson } from "@/types/sanity";
 import { SECTIONS, RECOMMENDED_SECTIONS } from "./sections";
 
 /**
@@ -18,9 +18,9 @@ import { SECTIONS, RECOMMENDED_SECTIONS } from "./sections";
  *
  * Key: 同じレッスンが複数のセクション/サブセクションに属することを許可（break しない）
  */
-export function groupLessonsNested(lessons: LessonWithArticleIds[]) {
+export function groupLessonsNested(lessons: Lesson[]) {
   // セクションID -> サブセクションID -> レッスン配列
-  const groups: Record<string, Record<string, LessonWithArticleIds[]>> = {};
+  const groups: Record<string, Record<string, Lesson[]>> = {};
 
   // 初期化
   SECTIONS.forEach(section => {
@@ -121,8 +121,8 @@ export function groupLessonsNested(lessons: LessonWithArticleIds[]) {
  * おすすめタブ用のレッスングルーピング
  * mainブランチの recommendedLessons ロジック（lines 357-378）をコピー
  */
-export function groupRecommendedLessons(lessons: LessonWithArticleIds[]) {
-  const groups: Record<string, LessonWithArticleIds[]> = {};
+export function groupRecommendedLessons(lessons: Lesson[]) {
+  const groups: Record<string, Lesson[]> = {};
 
   RECOMMENDED_SECTIONS.forEach(section => {
     groups[section.id] = [];
@@ -147,7 +147,7 @@ export function groupRecommendedLessons(lessons: LessonWithArticleIds[]) {
  * セクションごとの総レッスン数を計算
  * mainブランチの sectionCounts ロジック（lines 382-392）をコピー
  */
-export function getSectionCounts(groupedLessons: Record<string, Record<string, LessonWithArticleIds[]>>) {
+export function getSectionCounts(groupedLessons: Record<string, Record<string, Lesson[]>>) {
   const counts: Record<string, number> = {};
   SECTIONS.forEach(section => {
     let total = 0;

--- a/src/app/lessons/page.tsx
+++ b/src/app/lessons/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { getAllLessonsWithArticleIds } from "@/lib/sanity";
+import { getAllLessons } from "@/lib/sanity";
 // TODO: LessonCardに進捗表示を追加する際に使用
 // import { getMultipleLessonProgress } from "@/lib/services/progress";
 import PageHeader from "@/components/common/PageHeader";
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
 };
 
 export default async function LessonsPage() {
-  const lessons = await getAllLessonsWithArticleIds();
+  const lessons = await getAllLessons();
 
   // セクション・サブセクションごとにグルーピング（main の groupedLessons に対応）
   const groupedLessons = groupLessonsNested(lessons);

--- a/src/lib/services/progress.ts
+++ b/src/lib/services/progress.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getCachedUser } from "@/lib/supabase/server";
 
 // ============================================
 // 型定義
@@ -244,10 +244,9 @@ export async function getLessonProgress(
   articleIds: string[]
 ): Promise<LessonProgress> {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    // 認証はリクエストスコープでメモ化された getCachedUser を使い、
+    // 同一レンダー内の他の auth.getUser 呼び出しと往復を共有する
+    const user = await getCachedUser();
 
     if (!user || articleIds.length === 0) {
       return {
@@ -259,6 +258,9 @@ export async function getLessonProgress(
         lastUpdatedAt: null,
       };
     }
+
+    // DB クエリ用に Supabase クライアントを生成
+    const supabase = await createClient();
 
     // そのレッスンの記事で完了しているものを取得
     const { data } = await supabase


### PR DESCRIPTION
### #1 一覧（最大の効果）
`getAllLessonsWithArticleIds`（全レッスンで quests→articles を2階層フルderef）→ 軽量 `getAllLessons` に差し替え。一覧UIはネストデータ未使用のため表示不変。

### #2 詳細
quest毎に `getLessonProgress` を直列awaitしていたN+1を解消（全articleIds 1回取得→quest別ローカル集計）。`getLessonProgress` を `getCachedUser` 化し認証をdedup。進捗の数値は不変。

検証: tsc緑 / build緑 / dev で一覧・詳細が正常描画

🤖 Generated with [Claude Code](https://claude.com/claude-code)