### PR TITLE
perf: 記事詳細の認証4→1集約 + ヒーロー画像LCP最適化

### DIFF
--- a/src/components/article/VideoSection.tsx
+++ b/src/components/article/VideoSection.tsx
@@ -110,6 +110,8 @@ const VideoSection = ({
                 src={thumbnailSrc}
                 alt="記事サムネイル"
                 fill
+                priority
+                sizes="(min-width: 1024px) 800px, 100vw"
                 className="object-cover"
                 unoptimized
               />

--- a/src/lib/services/bookmarks.ts
+++ b/src/lib/services/bookmarks.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClient, getCachedUser } from "@/lib/supabase/server";
 import { client as getClient } from "@/lib/sanity";
 
 // ============================================
@@ -122,11 +122,12 @@ export async function toggleBookmark(
  */
 export async function isBookmarked(articleId: string): Promise<boolean> {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    // 認証はリクエストスコープでメモ化された getCachedUser を使い、
+    // 同一レンダー内の他の auth.getUser 呼び出しと往復を共有する
+    const user = await getCachedUser();
     if (!user) return false;
+
+    const supabase = await createClient();
 
     const { data } = await supabase
       .from("article_bookmarks")

--- a/src/lib/services/progress.ts
+++ b/src/lib/services/progress.ts
@@ -201,11 +201,12 @@ export async function getArticleProgress(
   articleId: string
 ): Promise<"completed" | "in_progress" | "not_started"> {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    // 認証はリクエストスコープでメモ化された getCachedUser を使い、
+    // 同一レンダー内の他の auth.getUser 呼び出しと往復を共有する
+    const user = await getCachedUser();
     if (!user) return "not_started";
+
+    const supabase = await createClient();
 
     const { data } = await supabase
       .from("article_progress")
@@ -440,11 +441,12 @@ export async function markLessonAsCompleted(
  */
 export async function getLessonStatus(lessonId: string): Promise<LessonStatus> {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    // 認証はリクエストスコープでメモ化された getCachedUser を使い、
+    // 同一レンダー内の他の auth.getUser 呼び出しと往復を共有する
+    const user = await getCachedUser();
     if (!user) return "not_started";
+
+    const supabase = await createClient();
 
     const { data } = await supabase
       .from("lesson_progress")


### PR DESCRIPTION
記事詳細(/contents/[slug])で `getLessonStatus`・`getArticleProgress`・`isBookmarked` が生 `auth.getUser()` のままで認証4往復発生していたのを `getCachedUser` に統一し**実質1回**に集約。返り値・表示は不変。

あわせて VideoSection のヒーロー画像(LCP)に `priority`+`sizes` を付与（非Sanityホスト対応のため `unoptimized` は維持）。

検証: tsc緑 / build緑 / dev で /contents 詳細が正常描画

🤖 Generated with [Claude Code](https://claude.com/claude-code)