### PR TITLE
perf(roadmap): 画像next/image化 + iconsax→lucide

### DIFF
--- a/src/components/roadmap/RoadmapCardV2.tsx
+++ b/src/components/roadmap/RoadmapCardV2.tsx
@@ -21,6 +21,7 @@
 
 import React, { useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { stripLineBreakMarker } from '@/utils/textFormat';
 import { type GradientPreset, GRADIENTS } from '@/styles/gradients';
@@ -107,10 +108,13 @@ const RoadmapCardV2: React.FC<RoadmapCardV2Props> = ({
                 style={{ background: gradientCSS }}
               >
                 {thumbnailUrl && (
-                  <img
+                  <Image
                     src={thumbnailUrl}
                     alt={title}
-                    className="absolute inset-0 w-full h-full object-cover"
+                    fill
+                    sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                    className="object-cover"
+                    unoptimized
                   />
                 )}
               </div>
@@ -122,11 +126,14 @@ const RoadmapCardV2: React.FC<RoadmapCardV2Props> = ({
               style={{ background: gradientCSS }}
             >
               {thumbnailUrl && (
-                <img
+                <Image
                   src={thumbnailUrl}
                   alt={title}
+                  fill
+                  sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
                   className="absolute inset-0 w-full h-full object-cover rounded-[16px] sm:rounded-[22px] lg:rounded-[30px] m-1.5 sm:m-2 lg:m-2.5"
                   style={{ width: 'calc(100% - 12px)', height: 'calc(100% - 12px)' }}
+                  unoptimized
                 />
               )}
             </div>
@@ -221,10 +228,13 @@ const RoadmapCardV2: React.FC<RoadmapCardV2Props> = ({
               style={{ background: gradientCSS }}
             >
               {thumbnailUrl && (
-                <img
+                <Image
                   src={thumbnailUrl}
                   alt={title}
-                  className="absolute inset-0 w-full h-full object-cover"
+                  fill
+                  sizes="(min-width: 1280px) 435px, (min-width: 1024px) 320px, 100vw"
+                  className="object-cover"
+                  unoptimized
                 />
               )}
             </div>
@@ -236,11 +246,16 @@ const RoadmapCardV2: React.FC<RoadmapCardV2Props> = ({
             style={{ background: gradientCSS }}
           >
             {thumbnailUrl && (
-              <img
-                src={thumbnailUrl}
-                alt={title}
-                className="absolute inset-2 sm:inset-3 w-[calc(100%-16px)] sm:w-[calc(100%-24px)] h-[calc(100%-16px)] sm:h-[calc(100%-24px)] object-cover rounded-[16px] sm:rounded-[22px] lg:rounded-[30px]"
-              />
+              <div className="absolute inset-2 sm:inset-3 overflow-hidden rounded-[16px] sm:rounded-[22px] lg:rounded-[30px]">
+                <Image
+                  src={thumbnailUrl}
+                  alt={title}
+                  fill
+                  sizes="(min-width: 1280px) 435px, (min-width: 1024px) 320px, 100vw"
+                  className="object-cover"
+                  unoptimized
+                />
+              </div>
             )}
           </div>
         )}

--- a/src/components/roadmap/detail/ChangingLandscape.tsx
+++ b/src/components/roadmap/detail/ChangingLandscape.tsx
@@ -7,7 +7,7 @@
  * 2026-04-02: 横型レイアウト（課題 → 矢印 → 解決）
  */
 
-import { MessageQuestion, ArrowRight2 } from "iconsax-react";
+import { MessageCircleQuestion, ArrowRight } from "lucide-react";
 import type { SanityChangingLandscape } from "@/types/sanity-roadmap";
 
 interface ChangingLandscapeProps {
@@ -61,10 +61,9 @@ export default function ChangingLandscape({ data }: ChangingLandscapeProps) {
               <div className="flex items-center gap-3 shrink-0 w-full md:w-[425px]">
                 {/* アイコン */}
                 <div className="flex items-center justify-center w-6 h-6 shrink-0">
-                  <MessageQuestion
+                  <MessageCircleQuestion
                     size={24}
                     color="#939993"
-                    variant="Linear"
                   />
                 </div>
 
@@ -76,7 +75,7 @@ export default function ChangingLandscape({ data }: ChangingLandscapeProps) {
 
               {/* 中央: 矢印アイコン（デスクトップのみ） */}
               <div className="hidden md:flex shrink-0 w-8 h-8 items-center justify-center">
-                <ArrowRight2 size={32} color="#939993" variant="Linear" />
+                <ArrowRight size={32} color="#939993" />
               </div>
 
               {/* 右側: 解決テキスト */}

--- a/src/components/roadmap/detail/ClearBlock.tsx
+++ b/src/components/roadmap/detail/ClearBlock.tsx
@@ -9,7 +9,7 @@
 import { useState, useCallback } from "react";
 import Link from "next/link";
 import confetti from "canvas-confetti";
-import { Cup, Edit, MessageText1, ArrowRight } from "iconsax-react";
+import { Trophy, Pencil, MessageSquareText, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface ClearBlockProps {
@@ -139,10 +139,9 @@ export default function ClearBlock({ roadmapTitle, roadmapSlug }: ClearBlockProp
                 size="large"
                 className="gap-3"
               >
-                <Cup
+                <Trophy
                   size={20}
                   color="currentColor"
-                  variant={celebrated ? "Bold" : "Outline"}
                 />
                 {celebrated ? "おめでとう！" : "クリアをお祝いする！"}
               </Button>
@@ -164,7 +163,7 @@ export default function ClearBlock({ roadmapTitle, roadmapSlug }: ClearBlockProp
                   >
                     <div className="flex items-start gap-4">
                       <div className="flex-shrink-0 w-12 h-12 bg-[#f0f4ee] rounded-xl flex items-center justify-center group-hover:bg-[#52674e]/10 transition-colors">
-                        <Edit size={24} color="#52674e" variant="Linear" />
+                        <Pencil size={24} color="#52674e" />
                       </div>
                       <div className="flex-1">
                         <h3 className="text-[16px] font-bold text-text-secondary mb-2">
@@ -190,7 +189,7 @@ export default function ClearBlock({ roadmapTitle, roadmapSlug }: ClearBlockProp
                   >
                     <div className="flex items-start gap-4">
                       <div className="flex-shrink-0 w-12 h-12 bg-[#f0f0fa] rounded-xl flex items-center justify-center group-hover:bg-[#667eea]/10 transition-colors">
-                        <MessageText1 size={24} color="#667eea" variant="Linear" />
+                        <MessageSquareText size={24} color="#667eea" />
                       </div>
                       <div className="flex-1">
                         <h3 className="text-[16px] font-bold text-text-secondary mb-2">
@@ -214,7 +213,7 @@ export default function ClearBlock({ roadmapTitle, roadmapSlug }: ClearBlockProp
                   <div className="bg-white rounded-2xl border border-[#e2e8e0] p-6 hover:border-[#52674e]/30 hover:shadow-[0_4px_16px_rgba(0,0,0,0.06)] transition-[border-color,box-shadow] group">
                     <div className="flex items-start gap-4">
                       <div className="flex-shrink-0 w-12 h-12 bg-[#f0f4ee] rounded-xl flex items-center justify-center group-hover:bg-[#52674e]/10 transition-colors">
-                        <Edit size={24} color="#52674e" variant="Linear" />
+                        <Pencil size={24} color="#52674e" />
                       </div>
                       <div className="flex-1">
                         <h3 className="text-[16px] font-bold text-text-secondary mb-2">
@@ -244,7 +243,7 @@ export default function ClearBlock({ roadmapTitle, roadmapSlug }: ClearBlockProp
                   >
                     <div className="flex items-start gap-4">
                       <div className="flex-shrink-0 w-12 h-12 bg-[#f0f0fa] rounded-xl flex items-center justify-center group-hover:bg-[#667eea]/10 transition-colors">
-                        <MessageText1 size={24} color="#667eea" variant="Linear" />
+                        <MessageSquareText size={24} color="#667eea" />
                       </div>
                       <div className="flex-1">
                         <h3 className="text-[16px] font-bold text-text-secondary mb-2">

--- a/src/components/roadmap/detail/InterestingPerspectives.tsx
+++ b/src/components/roadmap/detail/InterestingPerspectives.tsx
@@ -6,7 +6,7 @@
  * Figma: PRD🏠_Roadmap_2026 node-id 1-5906
  */
 
-import { Verify } from "iconsax-react";
+import { BadgeCheck } from "lucide-react";
 import type { SanityInterestingPerspectives } from "@/types/sanity-roadmap";
 
 interface InterestingPerspectivesProps {
@@ -69,7 +69,7 @@ export default function InterestingPerspectives({
                 <div className="flex items-center gap-6">
                   {/* アイコン */}
                   <div className="flex-shrink-0">
-                    <Verify size={24} color="#52674e" variant="Linear" />
+                    <BadgeCheck size={24} color="#52674e" />
                   </div>
 
                   {/* テキストコンテンツ */}

--- a/src/components/roadmap/detail/LessonContentItem.tsx
+++ b/src/components/roadmap/detail/LessonContentItem.tsx
@@ -5,6 +5,7 @@
  */
 
 import Link from "next/link";
+import Image from "next/image";
 import { ChevronRight, BookOpen } from "lucide-react";
 import type { SanityReferenceContent } from "@/types/sanity-roadmap";
 
@@ -27,12 +28,15 @@ export default function LessonContentItem({ content }: LessonContentItemProps) {
       style={{ transition: 'transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease' }}
     >
       {/* アイコン画像 - 右側のみ角丸 */}
-      <div className="flex-shrink-0 w-[106px] h-[160px] overflow-hidden rounded-r-lg shadow-[0_1px_24px_rgba(0,0,0,0.16)]">
+      <div className="relative flex-shrink-0 w-[106px] h-[160px] overflow-hidden rounded-r-lg shadow-[0_1px_24px_rgba(0,0,0,0.16)]">
         {imageUrl ? (
-          <img
+          <Image
             src={imageUrl}
             alt={content.title}
-            className="w-full h-full object-cover"
+            fill
+            sizes="106px"
+            className="object-cover"
+            unoptimized
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-100 to-gray-200">

--- a/src/components/roadmap/detail/RoadmapHero.tsx
+++ b/src/components/roadmap/detail/RoadmapHero.tsx
@@ -8,6 +8,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { motion } from "framer-motion";
 import { BackButton } from "@/components/common/BackButton";
 import type { GradientPreset } from "@/types/sanity-roadmap";
@@ -273,10 +274,13 @@ export default function RoadmapHero({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1], delay: 0.1 }}
           >
-            <img
+            <Image
               src={heroImageUrl}
               alt={stripLineBreakMarker(title)}
-              className="w-full h-full object-cover object-center opacity-90"
+              fill
+              priority
+              sizes="(min-width: 1200px) 1200px, 100vw"
+              className="object-cover object-center opacity-90"
             />
           </motion.div>
         )}

--- a/src/components/roadmap/detail/RoadmapPathway.tsx
+++ b/src/components/roadmap/detail/RoadmapPathway.tsx
@@ -7,7 +7,7 @@
  * ヒーローの直後に配置して、ロードマップ全体の流れを提示
  */
 
-import { ArrowDown2 } from "iconsax-react";
+import { ChevronDown } from "lucide-react";
 import type { SanityRoadmapStep } from "@/types/sanity-roadmap";
 import DottedDivider from "@/components/common/DottedDivider";
 
@@ -91,7 +91,7 @@ export default function RoadmapPathway({ description, steps }: RoadmapPathwayPro
                     {/* 下矢印アイコン */}
                     <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-full bg-muted-custom">
                       <div className="transition-transform duration-500 group-hover:rotate-[360deg]">
-                        <ArrowDown2 size={16} color="#9ca3af" variant="Linear" />
+                        <ChevronDown size={16} color="#9ca3af" />
                       </div>
                     </div>
                   </button>


### PR DESCRIPTION
安全な画像/バンドル改善（ISR静的化はCTAチラつきUXリスクのため見送り）。

- 生`<img>`→`next/image`（ヒーローは priority+sizes、サムネは sizes。AVIFは既存設定で自動適用）。非Sanityホストを含みうるサムネは `unoptimized` 維持。
- iconsax-react→lucide-react（4コンポーネント）。字形は近似置換。

検証: tsc緑 / build緑 / lint緑 / dev で一覧・詳細が正常描画

🤖 Generated with [Claude Code](https://claude.com/claude-code)