### PR TITLE
perf: 記事本文RichTextSectionをServer Component化（@portabletext/reactをクライアントから除去）

### DIFF
--- a/src/components/article/RichTextSection.tsx
+++ b/src/components/article/RichTextSection.tsx
@@ -1,5 +1,6 @@
-"use client";
-
+// Server Component。PortableText の描画はサーバー側で行い @portabletext/react を
+// クライアントバンドルから外す。唯一のインタラクティブ要素 ContentPreviewOverlay は
+// それ自身が "use client" の子コンポーネントなので Server から描画してOK。
 import { PortableText, PortableTextComponents } from "@portabletext/react";
 import { PortableTextBlock } from "@portabletext/types";
 import Link from "next/link";


### PR DESCRIPTION
`RichTextSection` は "use client" だったが自身にクライアントロジックが無く、描画元は全てServer Component。`"use client"` を外してServer Component化し、`@portabletext/react` の描画をサーバーに寄せてクライアントバンドルから除去（記事/体験談/イベント詳細のJS削減）。HTMLは不変。

検証: tsc緑 / build緑（境界エラーなし）/ dev で /contents・/stories 詳細が正常描画

🤖 Generated with [Claude Code](https://claude.com/claude-code)