### PR TITLE
perf: training詳細のEdge Function二重呼び + events詳細の認証重複を解消

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import { getEvent } from "@/lib/sanity";
-import { createClient } from "@/lib/supabase/server";
+import { getCachedUser } from "@/lib/supabase/server";
 import { getSubscriptionStatus } from "@/lib/subscription";
 import RichTextSection from "@/components/article/RichTextSection";
 import EventRegistrationButton from "@/components/event/EventRegistrationButton";
@@ -76,10 +76,8 @@ export default async function EventDetailPage({ params }: PageProps) {
   }
 
   // ユーザー・サブスクリプション状態を取得
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // getCachedUser（React cache）で、下の getSubscriptionStatus と認証往復を共有する
+  const user = await getCachedUser();
 
   let hasMemberAccess = false;
   if (user) {

--- a/src/lib/services/training/task-detail.ts
+++ b/src/lib/services/training/task-detail.ts
@@ -1,4 +1,5 @@
 import 'server-only'
+import { cache } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { getTrainingTaskDetailFromSanity } from "@/lib/sanity";
 import type { TaskDetailData } from "@/types/training";
@@ -100,7 +101,7 @@ const validateAndTransformResponse = (
  *    （タスク本文は Storage にしかないため、コンテンツなしで返す）
  * 3. TrainingError をスロー（呼び出し元で notFound() 処理）
  */
-export const getTrainingTaskDetail = async (
+export const getTrainingTaskDetail = cache(async (
   trainingSlug: string,
   taskSlug: string
 ): Promise<TaskDetailData> => {
@@ -225,4 +226,4 @@ export const getTrainingTaskDetail = async (
       );
     }
   }
-};
+});

--- a/src/lib/services/training/training-detail.ts
+++ b/src/lib/services/training/training-detail.ts
@@ -1,4 +1,5 @@
 import 'server-only'
+import { cache } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { getTrainingDetailFromSanity } from "@/lib/sanity";
 import type { TrainingDetailData } from "@/types/training";
@@ -12,7 +13,7 @@ import { TrainingError } from "@/lib/errors";
  * 2. Sanity CMS 直接クエリ
  * 3. TrainingError をスロー（呼び出し元で notFound() 処理）
  */
-export const getTrainingDetail = async (
+export const getTrainingDetail = cache(async (
   slug: string
 ): Promise<TrainingDetailData> => {
   if (!slug || slug.trim() === "") {
@@ -113,4 +114,4 @@ export const getTrainingDetail = async (
       );
     }
   }
-};
+});


### PR DESCRIPTION
不可視なデータ層のみの最適化（レンダリング不変・UI/機能に影響なし）:
- `getTrainingDetail`/`getTrainingTaskDetail` を React `cache()` 化。generateMetadata+本体での二重 `functions.invoke`（最遅ホップ）を1回に。
- events詳細: 生 `getUser()`→`getCachedUser()`。`getSubscriptionStatus` と認証を共有し2往復→1。

検証: tsc緑 / build緑 / dev で training詳細・タスク詳細が正常描画

🤖 Generated with [Claude Code](https://claude.com/claude-code)