### PR TITLE
fix(mypage): マイページのカードをスマホで縦積みに（レスポンシブ対応）

### DIFF
--- a/src/app/mypage/_shared/MySection.tsx
+++ b/src/app/mypage/_shared/MySection.tsx
@@ -42,7 +42,7 @@ export function MySection({
       {isEmpty ? (
         <EmptyState message={emptyMessage} link={emptyLink} />
       ) : horizontal ? (
-        <div className="flex gap-[10px] w-full">
+        <div className="flex flex-col sm:flex-row gap-[10px] w-full">
           {React.Children.map(children, (child) => (
             <div className="flex-1 min-w-0">{child}</div>
           ))}

--- a/src/app/mypage/skeletons/ProgressSkeleton.tsx
+++ b/src/app/mypage/skeletons/ProgressSkeleton.tsx
@@ -12,7 +12,7 @@ export function ProgressSkeleton({ mode }: { mode: "preview" | "full" }) {
           <Skeleton className="h-6 w-20" />
           <Skeleton className="h-4 w-16" />
         </div>
-        <div className="flex gap-[10px] w-full">
+        <div className="flex flex-col sm:flex-row gap-[10px] w-full">
           {[0, 1].map((i) => (
             <div key={i} className="flex-1 min-w-0">
               <ProgressCardSkeleton />


### PR DESCRIPTION
## 変更内容

マイページの横並びカードコンテナを `flex` → `flex flex-col sm:flex-row` に変更。

- **スマホ（〜639px）**: カードが縦積み
- **PC（640px〜）**: 従来どおり横並び

対象:
- `src/app/mypage/_shared/MySection.tsx`（実表示）
- `src/app/mypage/skeletons/ProgressSkeleton.tsx`（ローディング）

## 確認

- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 通過

スタイル（Tailwindクラス）のみの変更でロジック・データには非依存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)